### PR TITLE
Support mobile redirects

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -112,6 +112,22 @@ type Client struct {
 	mu sync.Mutex
 }
 
+func (c *Client) NeedsMobileRedirect() bool {
+	splitted := strings.Split(c.Name, ".")
+	last := splitted[len(splitted)-1]
+	return last == "android" || last == "ios"
+}
+
+func (c *Client) MobileRedirect() string {
+	vals := map[string]string{
+		"org.letsconnect-vpn.app.ios": "org.letsconnect-vpn.app.ios:/api/callback",
+		"org.letsconnect-vpn.app.android": "org.letsconnect-vpn.app:/api/callback",
+		"org.eduvpn.app.ios": "org.eduvpn.app.ios:/api/callback",
+		"org.eduvpn.app.android": "org.eduvpn.app:/api/callback",
+	}
+	return vals[c.Name]
+}
+
 func (c *Client) updateTokens(srv server.Server) error {
 	if c.TokenGetter == nil {
 		return errors.New("no token getter defined")
@@ -360,15 +376,39 @@ func (c *Client) locationCallback(ck *cookie.Cookie) error {
 }
 
 func (c *Client) loginCallback(ck *cookie.Cookie, srv server.Server) error {
-	url, err := server.OAuthURL(srv, c.Name)
+	// get a custom redirect
+	cr := ""
+	if c.NeedsMobileRedirect() {
+		cr = c.MobileRedirect()
+	}
+	url, err := server.OAuthURL(srv, c.Name, cr)
 	if err != nil {
 		return err
 	}
-	err = c.FSM.GoTransitionRequired(StateOAuthStarted, url)
-	if err != nil {
-		return err
+	authCodeURI := ""
+	if c.NeedsMobileRedirect() {
+		errChan := make(chan error)
+		go func() {
+			err := c.FSM.GoTransitionRequired(StateOAuthStarted, &srvtypes.RequiredAskTransition{
+				C:    ck,
+				Data: url,
+			})
+			if err != nil {
+				errChan <- err
+			}
+		}()
+		g, err := ck.Receive(errChan)
+		if err != nil {
+			return err
+		}
+		authCodeURI = g
+	} else {
+		err = c.FSM.GoTransitionRequired(StateOAuthStarted, url)
+		if err != nil {
+			return err
+		}
 	}
-	err = server.OAuthExchange(ck.Context(), srv)
+	err = server.OAuthExchange(ck.Context(), srv, authCodeURI)
 	if err != nil {
 		return err
 	}

--- a/client/redirect.go
+++ b/client/redirect.go
@@ -1,0 +1,23 @@
+package client
+
+// customRedirects supplies redirect values that should be handled by the app itself
+// here we hardcode the redirect values that we should use in the OAuth requests
+// these values were taken from https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
+var customRedirects = map[string]string{
+	"org.letsconnect-vpn.app.ios": "org.letsconnect-vpn.app.ios:/api/callback",
+	"org.letsconnect-vpn.app.android": "org.letsconnect-vpn.app:/api/callback",
+	"org.eduvpn.app.ios": "org.eduvpn.app.ios:/api/callback",
+	"org.eduvpn.app.android": "org.eduvpn.app:/api/callback",
+}
+
+// CustomRedirect returns the custom redirect string for a clientID `cid`
+// Empty string if none is defined or one is defined but is empty.
+// In both empty string cases, eduvpn-common handles the redirects as 127.0.0.1 local server redirects
+// If a non-empty string is returned, the redirect should be handled by the client and we only use the redirect URI value in our OAuth requests
+func CustomRedirect(cid string) string {
+	v, ok := customRedirects[cid]
+	if !ok {
+		return ""
+	}
+	return v
+}

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -86,7 +86,15 @@ The following state callbacks are mandatory to handle:
 
   - OAUTH_STARTED: This indicates that the OAuth procedure has been started,
     it returns the URL as the data. The client should open the webbrowser
-    with this URL and continue the authorization process.
+    with this URL and continue the authorization process. Note: For mobile
+    platforms this returns a Cookie and data (json: {"cookie": x, "data":
+    url}). This `url` should also be opened in the browser like desktop
+    platforms. But these platforms also need to reply to the library
+    to give back the full authorization code URI with CookieReply(x,
+    uri) that the apps get back when the user clicks approve. For this,
+    apps need to register an app url or sorts. For the valid values
+    for app URLs, see the redirect URIs for mobile platforms here
+    https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 
 Example Input (3=custom server): ```AddServer(mycookie, 3,
 "https://demo.eduvpn.nl", 0)```
@@ -483,8 +491,17 @@ So a client would:
 
 ### OAUTH_STARTED
 
-This indicates that the OAuth procedure has been started, it returns the URL
-as the data.
+  - OAUTH_STARTED: This indicates that the OAuth procedure has been started,
+    it returns the URL as the data. The client should open the webbrowser
+    with this URL and continue the authorization process. Note: For mobile
+    platforms this returns a Cookie and data (json: {"cookie": x, "data":
+    url}). This `url` should also be opened in the browser like desktop
+    platforms. But these platforms also need to reply to the library
+    to give back the full authorization code URI with CookieReply(x,
+    uri) that the apps get back when the user clicks approve. For this,
+    apps need to register an app url or sorts. For the valid values
+    for app URLs, see the redirect URIs for mobile platforms here
+    https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 
 The client should open the webbrowser with this URL and continue the
 authorization process. This is only called if authorization needs to be

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -87,13 +87,14 @@ The following state callbacks are mandatory to handle:
   - OAUTH_STARTED: This indicates that the OAuth procedure has been started,
     it returns the URL as the data. The client should open the webbrowser
     with this URL and continue the authorization process. Note: For mobile
-    platforms this returns a Cookie and data (json: {"cookie": x, "data":
-    url}). This `url` should also be opened in the browser like desktop
-    platforms. But these platforms also need to reply to the library
-    to give back the full authorization code URI with CookieReply(x,
-    uri) that the apps get back when the user clicks approve. For this,
-    apps need to register an app url or sorts. For the valid values
-    for app URLs, see the redirect URIs for mobile platforms here
+    platforms this returns a Cookie and data (json: `{"cookie": x, "data":
+    url}`). This `url` should also be opened in the browser like desktop
+    platforms. But these platforms also need to reply to the library to give
+    back the full authorization code URI with `CookieReply(x, uri)`. E.g.
+    `CookieReply(x, "/callback?code=...&state=...&iss=...")` this is the
+    path of the request that the apps get back when the user clicks approve.
+    For this, apps need to register an app url or sorts. For the valid
+    values for app URLs, see the redirect URIs for mobile platforms here
     https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 
 Example Input (3=custom server): ```AddServer(mycookie, 3,
@@ -494,13 +495,14 @@ So a client would:
   - OAUTH_STARTED: This indicates that the OAuth procedure has been started,
     it returns the URL as the data. The client should open the webbrowser
     with this URL and continue the authorization process. Note: For mobile
-    platforms this returns a Cookie and data (json: {"cookie": x, "data":
-    url}). This `url` should also be opened in the browser like desktop
-    platforms. But these platforms also need to reply to the library
-    to give back the full authorization code URI with CookieReply(x,
-    uri) that the apps get back when the user clicks approve. For this,
-    apps need to register an app url or sorts. For the valid values
-    for app URLs, see the redirect URIs for mobile platforms here
+    platforms this returns a Cookie and data (json: `{"cookie": x, "data":
+    url}`). This `url` should also be opened in the browser like desktop
+    platforms. But these platforms also need to reply to the library to give
+    back the full authorization code URI with `CookieReply(x, uri)`. E.g.
+    `CookieReply(x, "/callback?code=...&state=...&iss=...")` this is the
+    path of the request that the apps get back when the user clicks approve.
+    For this, apps need to register an app url or sorts. For the valid
+    values for app URLs, see the redirect URIs for mobile platforms here
     https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 
 The client should open the webbrowser with this URL and continue the

--- a/docs/src/api/statemachine.md
+++ b/docs/src/api/statemachine.md
@@ -171,7 +171,7 @@ For the explanation of what all the different states mean, see the [client docum
 
 In eduvpn-common, there are certain states that require attention from the client.
 
-- OAuth Started: A state that must be handled by the client. How a client can 'handle' this state, we will see in the next section. In this state, the client must open the webbrowser with the authorization URL to complete to OAuth process
+- OAuth Started: A state that must be handled by the client. How a client can 'handle' this state, we will see in the next section. In this state, the client must open the webbrowser with the authorization URL to complete to OAuth process. Note that on mobile platforms, you also need to reply with the authorization URI as these platforms do not support a local callback server using 127.0.0.1
 - Ask Profile: The state that asks for a profile selection to the client. Reply to this state by using a "cookie" and the CookieReply function. What this means will be discussed in the Python client example too
 - Ask Location: Same for ask profile but for selecting a secure internet location. Only called if one must be chosen, e.g. due to a selection that is no longer valid
 

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -290,7 +290,8 @@ func Deregister() *C.char {
 // The following state callbacks are mandatory to handle:
 //
 //   - OAUTH_STARTED: This indicates that the OAuth procedure has been started, it returns the URL as the data.
-//     The client should open the webbrowser with this URL and continue the authorization process.
+//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: {"cookie": x, "data": url}).
+//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with CookieReply(x, uri) that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 //
 // Example Input (3=custom server):
 // ```AddServer(mycookie, 3, "https://demo.eduvpn.nl", 0)```
@@ -542,7 +543,9 @@ func ServerList() (*C.char, *C.char) {
 //
 // ### OAUTH_STARTED
 //
-// This indicates that the OAuth procedure has been started, it returns the URL as the data.
+//   - OAUTH_STARTED: This indicates that the OAuth procedure has been started, it returns the URL as the data.
+//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: {"cookie": x, "data": url}).
+//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with CookieReply(x, uri) that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 //
 // The client should open the webbrowser with this URL and continue the authorization process.
 // This is only called if authorization needs to be retriggered

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -290,8 +290,9 @@ func Deregister() *C.char {
 // The following state callbacks are mandatory to handle:
 //
 //   - OAUTH_STARTED: This indicates that the OAuth procedure has been started, it returns the URL as the data.
-//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: {"cookie": x, "data": url}).
-//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with CookieReply(x, uri) that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
+//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: `{"cookie": x, "data": url}`).
+//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with `CookieReply(x, uri)`.
+//     E.g. `CookieReply(x, "/callback?code=...&state=...&iss=...")` this is the path of the request that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 //
 // Example Input (3=custom server):
 // ```AddServer(mycookie, 3, "https://demo.eduvpn.nl", 0)```
@@ -544,8 +545,9 @@ func ServerList() (*C.char, *C.char) {
 // ### OAUTH_STARTED
 //
 //   - OAUTH_STARTED: This indicates that the OAuth procedure has been started, it returns the URL as the data.
-//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: {"cookie": x, "data": url}).
-//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with CookieReply(x, uri) that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
+//     The client should open the webbrowser with this URL and continue the authorization process. Note: For mobile platforms this returns a Cookie and data (json: `{"cookie": x, "data": url}`).
+//     This `url` should also be opened in the browser like desktop platforms. But these platforms also need to reply to the library to give back the full authorization code URI with `CookieReply(x, uri)`.
+//     E.g. `CookieReply(x, "/callback?code=...&state=...&iss=...")` this is the path of the request that the apps get back when the user clicks approve. For this, apps need to register an app url or sorts. For the valid values for app URLs, see the redirect URIs for mobile platforms here https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
 //
 // The client should open the webbrowser with this URL and continue the authorization process.
 // This is only called if authorization needs to be retriggered

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -110,6 +110,9 @@ type exchangeSession struct {
 	// Verifier is the preimage of the challenge
 	Verifier string
 
+	// RedirectURI is the passed redirect URI
+	RedirectURI string
+
 	// Listener is the listener where the servers 'listens' on
 	Listener net.Listener
 
@@ -132,14 +135,13 @@ func (oauth *OAuth) AccessToken(ctx context.Context) (string, error) {
 // If it was unsuccessful it returns an error.
 // @see https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-07.html#section-8.4.2
 // "Loopback Interface Redirection".
-func (oauth *OAuth) setupListener() error {
+func (oauth *OAuth) setupListener() (net.Listener, error) {
 	// create a listener
 	lst, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return errors.WrapPrefix(err, "net.Listen failed", 0)
+		return nil, errors.WrapPrefix(err, "net.Listen failed", 0)
 	}
-	oauth.session.Listener = lst
-	return nil
+	return lst, nil
 }
 
 // tokensWithCallback gets the OAuth tokens using a local web server
@@ -228,17 +230,12 @@ func (oauth *OAuth) tokensWithAuthCode(ctx context.Context, authCode string) err
 	// so that the server can verify that we are the actual owner of the authorization code
 	u := oauth.TokenURL
 
-	port, err := oauth.ListenerPort()
-	if err != nil {
-		return err
-	}
-
 	data := url.Values{
 		"client_id":     {oauth.ClientID},
 		"code":          {authCode},
 		"code_verifier": {oauth.session.Verifier},
 		"grant_type":    {"authorization_code"},
-		"redirect_uri":  {fmt.Sprintf("http://127.0.0.1:%d/callback", port)},
+		"redirect_uri":  {oauth.session.RedirectURI},
 	}
 	h := http.Header{
 		"content-type": {"application/x-www-form-urlencoded"},
@@ -436,15 +433,6 @@ func (oauth *OAuth) Init(clientID string, iss string, baseAuthorizationURL strin
 	oauth.TokenURL = tokenURL
 }
 
-// ListenerPort gets the listener for the OAuth web server
-// It returns the port as an integer and an error if there is any.
-func (oauth *OAuth) ListenerPort() (int, error) {
-	if oauth.session.Listener == nil {
-		return 0, errors.New("failed to get listener port")
-	}
-	return oauth.session.Listener.Addr().(*net.TCPAddr).Port, nil
-}
-
 // AuthURL gets the authorization url to start the OAuth procedure.
 func (oauth *OAuth) AuthURL(name string, postProcessAuth func(string) string, cr string) (string, error) {
 	// Update the client ID
@@ -466,26 +454,27 @@ func (oauth *OAuth) AuthURL(name string, postProcessAuth func(string) string, cr
 	oauth.UpdateTokens(Token{})
 
 	// Fill the struct with the necessary fields filled for the next call to getting the HTTP client
+	red := cr
+
+	// no custom redirect URI defined, we setup our own
+	var l net.Listener
+	if cr == "" {
+		// set up the listener to get the redirect URI
+		l, err = oauth.setupListener()
+		if err != nil {
+			return "", errors.WrapPrefix(err, "oauth.setupListener error", 0)
+		}
+		port := l.Addr().(*net.TCPAddr).Port
+		// see https://git.sr.ht/~fkooman/vpn-user-portal/tree/v3/item/src/OAuth/VpnClientDb.php
+		red = fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+	}
 	oauth.session = exchangeSession{
 		ISS:      oauth.ISS,
 		State:    state,
 		Verifier: v,
 		ErrChan:  make(chan error),
-	}
-
-	// set up the listener to get the redirect URI
-	if err = oauth.setupListener(); err != nil {
-		return "", errors.WrapPrefix(err, "oauth.setupListener error", 0)
-	}
-
-	red := cr
-	if cr == "" {
-		// Get the listener port
-		port, err := oauth.ListenerPort()
-		if err != nil {
-			return "", errors.WrapPrefix(err, "oauth.ListenerPort error", 0)
-		}
-		red = fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+		RedirectURI: red,
+		Listener: l,
 	}
 
 	params := map[string]string{

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -3,7 +3,6 @@ package oauth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"strings"
 	"testing"
@@ -169,7 +168,7 @@ func Test_AuthURL(t *testing.T) {
 	s, err := o.AuthURL(id, func(s string) string {
 		// We do nothing here are this function is for skipping WAYF
 		return s
-	})
+	}, "")
 	if err != nil {
 		t.Fatalf("Error in getting OAuth URL: %v", err)
 	}
@@ -196,11 +195,6 @@ func Test_AuthURL(t *testing.T) {
 		t.Fatalf("Returned Auth URL cannot be parsed with error: %v", err)
 	}
 
-	port, err := o.ListenerPort()
-	if err != nil {
-		t.Fatalf("Listener port cannot be found with error: %v", err)
-	}
-
 	c := []struct {
 		query string
 		want  string
@@ -209,7 +203,7 @@ func Test_AuthURL(t *testing.T) {
 		{query: "code_challenge_method", want: "S256"},
 		{query: "response_type", want: "code"},
 		{query: "scope", want: "config"},
-		{query: "redirect_uri", want: fmt.Sprintf("http://127.0.0.1:%d/callback", port)},
+		{query: "redirect_uri", want: o.session.RedirectURI},
 	}
 
 	q := u.Query()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,12 +49,12 @@ func UpdateTokens(srv Server, t oauth.Token) {
 	srv.OAuth().UpdateTokens(t)
 }
 
-func OAuthURL(srv Server, name string) (string, error) {
-	return srv.OAuth().AuthURL(name, srv.TemplateAuth())
+func OAuthURL(srv Server, name string, cr string) (string, error) {
+	return srv.OAuth().AuthURL(name, srv.TemplateAuth(), cr)
 }
 
-func OAuthExchange(ctx context.Context, srv Server) error {
-	return srv.OAuth().Exchange(ctx)
+func OAuthExchange(ctx context.Context, srv Server, uri string) error {
+	return srv.OAuth().Exchange(ctx, uri)
 }
 
 func HeaderToken(ctx context.Context, srv Server) (string, error) {


### PR DESCRIPTION
Mobile platforms do not support our 127.0.0.1 callback flow, let's make sure we support those by allowing those apps to forward the authorization response, e.g. `"/callback?code=...&state=...&is=..."`