### PR TITLE
Proxyguard update to solve client timing issues

### DIFF
--- a/client/proxy.go
+++ b/client/proxy.go
@@ -1,9 +1,6 @@
 package client
 
 import (
-	"net"
-	"net/url"
-
 	"codeberg.org/eduVPN/proxyguard"
 	"github.com/eduvpn/eduvpn-common/i18nerr"
 	"github.com/eduvpn/eduvpn-common/internal/log"
@@ -39,17 +36,8 @@ func (c *Client) StartProxyguard(ck *cookie.Cookie, listen string, tcpsp int, pe
 		ready()
 	}
 
-	u, err := url.Parse(peer)
-	if err != nil {
-		return i18nerr.Wrap(err, "The peer is not a valid URL")
-	}
-
-	pips, err := net.DefaultResolver.LookupHost(ck.Context(), u.Host)
-	if err != nil {
-		return i18nerr.Wrapf(err, "Cannot lookup peer host: '%s'", u.Host)
-	}
-
-	err = proxyguard.Client(ck.Context(), listen, tcpsp, peer, pips, -1)
+	// we set peer IPs to nil here as proxyguard already does a DNS request for us
+	err = proxyguard.Client(ck.Context(), listen, tcpsp, peer, nil, -1)
 	if err != nil {
 		return i18nerr.Wrap(err, "The VPN proxy exited")
 	}

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -28,7 +28,16 @@ func (c *Client) StartProxyguard(ck *cookie.Cookie, listen string, tcpsp int, pe
 	var err error
 	proxyguard.UpdateLogger(&ProxyLogger{})
 	proxyguard.GotClientFD = gotFD
-	proxyguard.ClientProxyReady = ready
+	proxyguard.ClientProxyReady = func() {
+		// already connected
+		// no need to signal to the client that the proxy is ready
+		if c.InState(StateConnected) {
+			log.Logger.Debugf("proxyguard is ready again when the client was already connected")
+			return
+		}
+		log.Logger.Debugf("forwarding proxyguard ready callback to client")
+		ready()
+	}
 
 	u, err := url.Parse(peer)
 	if err != nil {

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -844,7 +844,7 @@ Example Output: ```1, null```
 ## StartProxyguard
 Signature:
  ```go
-func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, proxyFD C.ProxyFD) *C.char
+func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, proxyFD C.ProxyFD, proxyReady C.ProxyReady) *C.char
 ```
 StartProxyguard starts the 'proxyguard' procedure in
 eduvpn-common. This proxies WireGuard UDP connections over HTTP:
@@ -859,6 +859,9 @@ from the configuration that is retrieved using the `proxy` JSON key
   - `proxyFD` is a callback with the file descriptor as only argument.
     It can be used to set certain socket option, e.g. to exclude the proxy
     connection from going over the VPN
+  - `proxyReady` is a callback when the proxy is ready to be used. This is
+    only called when the client is not connected yet. Use this to determine
+    when the actual wireguard connection can be started
 
 If the proxy cannot be started it returns an error
 

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -861,7 +861,8 @@ from the configuration that is retrieved using the `proxy` JSON key
     connection from going over the VPN
   - `proxyReady` is a callback when the proxy is ready to be used. This is
     only called when the client is not connected yet. Use this to determine
-    when the actual wireguard connection can be started
+    when the actual wireguard connection can be started. This callback
+    returns and takes no arguments
 
 If the proxy cannot be started it returns an error
 

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -912,7 +912,7 @@ func StartFailover(c C.uintptr_t, gateway *C.char, mtu C.int, readRxBytes C.Read
 //   - `peer` is the ip:port of the remote server
 //   - `proxyFD` is a callback with the file descriptor as only argument. It can be used to set certain
 //     socket option, e.g. to exclude the proxy connection from going over the VPN
-//   - `proxyReady` is a callback when the proxy is ready to be used. This is only called when the client is not connected yet. Use this to determine when the actual wireguard connection can be started
+//   - `proxyReady` is a callback when the proxy is ready to be used. This is only called when the client is not connected yet. Use this to determine when the actual wireguard connection can be started. This callback returns and takes no arguments
 //
 // If the proxy cannot be started it returns an error
 //

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -912,7 +912,7 @@ func StartFailover(c C.uintptr_t, gateway *C.char, mtu C.int, readRxBytes C.Read
 //   - `peer` is the ip:port of the remote server
 //   - `proxyFD` is a callback with the file descriptor as only argument. It can be used to set certain
 //     socket option, e.g. to exclude the proxy connection from going over the VPN
-//   - `proxyReady` is a callback when the proxy is ready to be used
+//   - `proxyReady` is a callback when the proxy is ready to be used. This is only called when the client is not connected yet. Use this to determine when the actual wireguard connection can be started
 //
 // If the proxy cannot be started it returns an error
 //

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -24,6 +24,7 @@ typedef int (*StateCB)(int oldstate, int newstate, void* data);
 typedef void (*TokenGetter)(const char* server_id, int server_type, char* out, size_t len);
 typedef void (*TokenSetter)(const char* server_id, int server_type, const char* tokens);
 typedef void (*ProxyFD)(int fd);
+typedef void (*ProxyReady)();
 
 static long long int get_read_rx_bytes(ReadRxBytes read)
 {
@@ -44,6 +45,10 @@ static void call_token_setter(TokenSetter setter, const char* server_id, int ser
 static void call_proxy_fd(ProxyFD proxyfd, int fd)
 {
     proxyfd(fd);
+}
+static void call_proxy_ready(ProxyReady ready)
+{
+    ready();
 }
 */
 import "C"
@@ -907,11 +912,12 @@ func StartFailover(c C.uintptr_t, gateway *C.char, mtu C.int, readRxBytes C.Read
 //   - `peer` is the ip:port of the remote server
 //   - `proxyFD` is a callback with the file descriptor as only argument. It can be used to set certain
 //     socket option, e.g. to exclude the proxy connection from going over the VPN
+//   - `proxyReady` is a callback when the proxy is ready to be used
 //
 // If the proxy cannot be started it returns an error
 //
 //export StartProxyguard
-func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, proxyFD C.ProxyFD) *C.char {
+func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, proxyFD C.ProxyFD, proxyReady C.ProxyReady) *C.char {
 	state, stateErr := getVPNState()
 	if stateErr != nil {
 		return getCError(stateErr)
@@ -926,6 +932,8 @@ func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, p
 			return
 		}
 		C.call_proxy_fd(proxyFD, C.int(fd))
+	}, func() {
+		C.call_proxy_ready(proxyReady)
 	})
 	return getCError(proxyErr)
 }

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -933,6 +933,9 @@ func StartProxyguard(c C.uintptr_t, listen *C.char, tcpsp C.int, peer *C.char, p
 		}
 		C.call_proxy_fd(proxyFD, C.int(fd))
 	}, func() {
+		if proxyReady == nil {
+			return
+		}
 		C.call_proxy_ready(proxyReady)
 	})
 	return getCError(proxyErr)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eduvpn/eduvpn-common
 go 1.18
 
 require (
-	codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2
+	codeberg.org/eduVPN/proxyguard v0.0.0-20240223093313-0b7963ba28b9
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267
 	github.com/jwijenbergh/eduoauth-go v0.0.0-20240212102633-770ef228bd93
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/eduvpn/eduvpn-common
 go 1.18
 
 require (
-	codeberg.org/eduVPN/proxyguard v0.0.0-20240213150724-adfa5487640a
+	codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267
 	github.com/jwijenbergh/eduoauth-go v0.0.0-20240212102633-770ef228bd93
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ codeberg.org/eduVPN/proxyguard v0.0.0-20240213150724-adfa5487640a h1:OH5xfNALCNH
 codeberg.org/eduVPN/proxyguard v0.0.0-20240213150724-adfa5487640a/go.mod h1:fc7DsdgdLmrO7DN45HNp+ekVewlRcikSOkAvUeGUvWk=
 codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2 h1:Vm4JtbNHY/W11ldulDK6rGw56vvQilv42pZ/jSWlIlc=
 codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2/go.mod h1:fc7DsdgdLmrO7DN45HNp+ekVewlRcikSOkAvUeGUvWk=
+codeberg.org/eduVPN/proxyguard v0.0.0-20240223093313-0b7963ba28b9 h1:rxCDQzVDiZXfzmOoPitZHus2X9uO9fgs4HmQoJfRerw=
+codeberg.org/eduVPN/proxyguard v0.0.0-20240223093313-0b7963ba28b9/go.mod h1:fc7DsdgdLmrO7DN45HNp+ekVewlRcikSOkAvUeGUvWk=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 h1:TMtDYDHKYY15rFihtRfck/bfFqNfvcabqvXAFQfAUpY=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267/go.mod h1:h1nSAbGFqGVzn6Jyl1R/iCcBUHN4g+gW1u9CoBTrb9E=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 codeberg.org/eduVPN/proxyguard v0.0.0-20240213150724-adfa5487640a h1:OH5xfNALCNHysHxYgTQy5qL4MT91cN7/lwtc4bzchQo=
 codeberg.org/eduVPN/proxyguard v0.0.0-20240213150724-adfa5487640a/go.mod h1:fc7DsdgdLmrO7DN45HNp+ekVewlRcikSOkAvUeGUvWk=
+codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2 h1:Vm4JtbNHY/W11ldulDK6rGw56vvQilv42pZ/jSWlIlc=
+codeberg.org/eduVPN/proxyguard v0.0.0-20240222150137-7a64d5af6bd2/go.mod h1:fc7DsdgdLmrO7DN45HNp+ekVewlRcikSOkAvUeGUvWk=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 h1:TMtDYDHKYY15rFihtRfck/bfFqNfvcabqvXAFQfAUpY=
 github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267/go.mod h1:h1nSAbGFqGVzn6Jyl1R/iCcBUHN4g+gW1u9CoBTrb9E=

--- a/wrappers/python/eduvpn_common/loader.py
+++ b/wrappers/python/eduvpn_common/loader.py
@@ -6,6 +6,8 @@ from ctypes import CDLL, c_char_p, c_int, c_void_p, cdll
 from eduvpn_common import __version__
 from eduvpn_common.types import (
     BoolError,
+    GotProxyFD,
+    ProxyReady,
     DataError,
     ReadRxBytes,
     TokenGetter,
@@ -130,5 +132,6 @@ def initialize_functions(lib: CDLL) -> None:
         c_char_p,
         c_int,
         c_char_p,
-        c_void_p,
+        GotProxyFD,
+        ProxyReady,
     ], c_void_p

--- a/wrappers/python/eduvpn_common/main.py
+++ b/wrappers/python/eduvpn_common/main.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, Iterator, Optional
 
 from eduvpn_common.loader import initialize_functions, load_lib
 from eduvpn_common.types import (
+    GotProxyFD,
+    ProxyReady,
     ReadRxBytes,
     TokenGetter,
     TokenSetter,
@@ -345,13 +347,14 @@ class EduVPN(object):
             forwardError(dropped_err)
         return dropped
 
-    def start_proxyguard(self, listen: str, source_port: int, peer: str):
+    def start_proxyguard(self, listen: str, source_port: int, peer: str, gotfd: GotProxyFD, ready: ProxyReady):
         proxy_err = self.go_cookie_function(
             self.lib.StartProxyguard,
             listen,
             source_port,
             peer,
-            0,
+            gotfd,
+            ready,
         )
         if proxy_err:
             forwardError(proxy_err)

--- a/wrappers/python/eduvpn_common/types.py
+++ b/wrappers/python/eduvpn_common/types.py
@@ -34,6 +34,8 @@ class BoolError(Structure):
 
 # The type for a Go state change callback
 VPNStateChange = CFUNCTYPE(c_int, c_int, c_int, c_char_p)
+GotProxyFD = CFUNCTYPE(c_void_p, c_int)
+ProxyReady = CFUNCTYPE(c_void_p)
 ReadRxBytes = CFUNCTYPE(c_ulonglong)
 TokenGetter = CFUNCTYPE(c_void_p, c_char_p, c_int, POINTER(c_char), c_size_t)
 TokenSetter = CFUNCTYPE(c_void_p, c_char_p, c_int, c_char_p)


### PR DESCRIPTION
- Add a ready callback when the proxy is ready, this callback takes no arguments and is the last argument of `StartProxyguard`. When this callback is called, the underlying wireguard connection should be set up as the proxy is then ready
- Do a DNS request for the proxy peer IPs so that reconnection can be done nicely