### PR TITLE
Installed shared library as part of the python package

### DIFF
--- a/wrappers/python/pyproject.toml
+++ b/wrappers/python/pyproject.toml
@@ -23,6 +23,9 @@ mypy = [ "mypy" ]
 [tool.setuptools.packages.find]
 include = ["eduvpn_common*"]
 
+[tool.setuptools.package-data]
+"eduvpn_common.lib" = ["*.so"]
+
 [tool.ruff]
 line-length = 120
 


### PR DESCRIPTION
During packaging version 1.99.2 for Gentoo Linux, I noticed the shared library is not part of the python wheel anymore. In the old `setup.py` where was a `shutil.copyfile`-instruction which got removed in 9bab3c87825b4284b3e6f2be3fa9e89da7723116. From my point of view, declaring the library as a data file should fix the problem. But I am unsure if this is the recommended solution.