### PR TITLE
Discovery: search & return less JSON keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,29 @@
+# 2.0.0
+* Minimise exposed discovery to the client and add search by giving a second argument to DiscoServers or DiscoOrganizations with the search query:
+  - organization list globally changes:
+    * remove `v` field
+    * remove `go_timestamp` field
+  - each organization changes:
+    * remove `authentication_url_template` field
+    * remove `keyword_list` field
+    * remove `public_key_list` field
+    * remove `support_contact` field
+  - server list globally changes:
+    * remove `v` field
+    * remove `go_timestamp` field
+  - each server changes:
+    * remove `secure_internet_home` field
+    * remove `keyword_list` field
+* Python wrapper:
+  - Add setup.py & setup.cfg for backwards compatibility instead of completely relying on pyproject.toml
+* API:
+  - Add a ton of tests by mocking the server API
+* Makefile:
+  - Add a coverage target
+* Server:
+  - Replace the non-interactive AddServer flag with an oauth start time flag,
+    if non-nil the server is added non-interactively and the OAuth start time is stored
+
 # 1.99.2 (2024-04-25)
 * Expose default gateway in profile settings too. For clients, use the default gateway set on the config object, this is maybe only useful for suggesting some profiles in the client profile chooser UI
 * Add a server internally before authorizing and remove it again if authorization has failed. This makes sure the internal state is always up-to-date with what is happening. This also allows us to move to the main state when authorization is done as previously it could be the case where authorization was done but the server was not added yet

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -17,32 +17,54 @@ func (c *Client) hasDiscovery() bool {
 // If the list cannot be retrieved an error is returned.
 // If this is the case then a previous version of the list is returned if there is any.
 // This takes into account the frequency of updates, see: https://github.com/eduvpn/documentation/blob/v3/SERVER_DISCOVERY.md#organization-list.
-func (c *Client) DiscoOrganizations(ck *cookie.Cookie) (orgs *discotypes.Organizations, err error) {
+func (c *Client) DiscoOrganizations(ck *cookie.Cookie) (*discotypes.Organizations, error) {
 	// Not supported with Let's Connect! & govVPN
 	if !c.hasDiscovery() {
 		return nil, i18nerr.NewInternal("Server/organization discovery with this client ID is not supported")
 	}
 
-	orgs, err = c.cfg.Discovery().Organizations(ck.Context())
+	orgs, err := c.cfg.Discovery().Organizations(ck.Context())
 	if err != nil {
 		err = i18nerr.Wrap(err, "An error occurred after getting the discovery files for the list of organizations")
 	}
-	return
+	if orgs == nil {
+		return nil, err
+	}
+
+	// convert to public subset
+	retOrgs := make([]discotypes.Organization, len(orgs.List))
+	for i, v := range orgs.List {
+		retOrgs[i] = v.Organization
+	}
+	return &discotypes.Organizations{
+		List: retOrgs,
+	}, err
 }
 
 // DiscoServers gets the servers list from the discovery server
 // If the list cannot be retrieved an error is returned.
 // If this is the case then a previous version of the list is returned if there is any.
 // This takes into account the frequency of updates, see: https://github.com/eduvpn/documentation/blob/v3/SERVER_DISCOVERY.md#server-list.
-func (c *Client) DiscoServers(ck *cookie.Cookie) (dss *discotypes.Servers, err error) {
+func (c *Client) DiscoServers(ck *cookie.Cookie) (*discotypes.Servers, error) {
 	// Not supported with Let's Connect! & govVPN
 	if !c.hasDiscovery() {
 		return nil, i18nerr.NewInternal("Server/organization discovery with this client ID is not supported")
 	}
 
-	dss, err = c.cfg.Discovery().Servers(ck.Context())
+	servs, err := c.cfg.Discovery().Servers(ck.Context())
 	if err != nil {
 		err = i18nerr.Wrap(err, "An error occurred after getting the discovery files for the list of servers")
 	}
-	return
+	if servs == nil {
+		return nil, err
+	}
+
+	// convert to public subset
+	retServs := make([]discotypes.Server, len(servs.List))
+	for i, v := range servs.List {
+		retServs[i] = v.Server
+	}
+	return &discotypes.Servers{
+		List: retServs,
+	}, err
 }

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -13,11 +13,11 @@ func (c *Client) hasDiscovery() bool {
 	return strings.HasPrefix(c.Name, "org.eduvpn.app")
 }
 
-// DiscoOrganizations gets the organizations list from the discovery server
+// DiscoOrganizations gets the organizations list from the discovery server with search string `search`
 // If the list cannot be retrieved an error is returned.
 // If this is the case then a previous version of the list is returned if there is any.
 // This takes into account the frequency of updates, see: https://github.com/eduvpn/documentation/blob/v3/SERVER_DISCOVERY.md#organization-list.
-func (c *Client) DiscoOrganizations(ck *cookie.Cookie) (*discotypes.Organizations, error) {
+func (c *Client) DiscoOrganizations(ck *cookie.Cookie, search string) (*discotypes.Organizations, error) {
 	// Not supported with Let's Connect! & govVPN
 	if !c.hasDiscovery() {
 		return nil, i18nerr.NewInternal("Server/organization discovery with this client ID is not supported")
@@ -32,20 +32,23 @@ func (c *Client) DiscoOrganizations(ck *cookie.Cookie) (*discotypes.Organization
 	}
 
 	// convert to public subset
-	retOrgs := make([]discotypes.Organization, len(orgs.List))
-	for i, v := range orgs.List {
-		retOrgs[i] = v.Organization
+	var retOrgs []discotypes.Organization
+	for _, v := range orgs.List {
+		if !v.Matches(search) {
+			continue
+		}
+		retOrgs = append(retOrgs, v.Organization)
 	}
 	return &discotypes.Organizations{
 		List: retOrgs,
 	}, err
 }
 
-// DiscoServers gets the servers list from the discovery server
+// DiscoServers gets the servers list from the discovery server with search string `search`
 // If the list cannot be retrieved an error is returned.
 // If this is the case then a previous version of the list is returned if there is any.
 // This takes into account the frequency of updates, see: https://github.com/eduvpn/documentation/blob/v3/SERVER_DISCOVERY.md#server-list.
-func (c *Client) DiscoServers(ck *cookie.Cookie) (*discotypes.Servers, error) {
+func (c *Client) DiscoServers(ck *cookie.Cookie, search string) (*discotypes.Servers, error) {
 	// Not supported with Let's Connect! & govVPN
 	if !c.hasDiscovery() {
 		return nil, i18nerr.NewInternal("Server/organization discovery with this client ID is not supported")
@@ -60,9 +63,12 @@ func (c *Client) DiscoServers(ck *cookie.Cookie) (*discotypes.Servers, error) {
 	}
 
 	// convert to public subset
-	retServs := make([]discotypes.Server, len(servs.List))
-	for i, v := range servs.List {
-		retServs[i] = v.Server
+	var retServs []discotypes.Server
+	for _, v := range servs.List {
+		if !v.Matches(search) {
+			continue
+		}
+		retServs = append(retServs, v.Server)
 	}
 	return &discotypes.Servers{
 		List: retServs,

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -36,8 +36,8 @@ func (c *Client) DiscoOrganizations(ck *cookie.Cookie, search string) (*discotyp
 	var retOrgs []discotypes.Organization
 	for _, v := range orgs.List {
 		if search == "" {
-		    retOrgs = append(retOrgs, v.Organization)
-		    continue
+			retOrgs = append(retOrgs, v.Organization)
+			continue
 		}
 		score := v.Score(search)
 		if score < 0 {
@@ -47,10 +47,10 @@ func (c *Client) DiscoOrganizations(ck *cookie.Cookie, search string) (*discotyp
 		retOrgs = append(retOrgs, v.Organization)
 	}
 	if search != "" {
-	    sort.Slice(retOrgs, func(i, j int) bool {
-		    // lower score is better
-		    return retOrgs[i].Score < retOrgs[j].Score
-	    })
+		sort.Slice(retOrgs, func(i, j int) bool {
+			// lower score is better
+			return retOrgs[i].Score < retOrgs[j].Score
+		})
 	}
 	return &discotypes.Organizations{
 		List: retOrgs,
@@ -79,8 +79,8 @@ func (c *Client) DiscoServers(ck *cookie.Cookie, search string) (*discotypes.Ser
 	var retServs []discotypes.Server
 	for _, v := range servs.List {
 		if search == "" {
-		    retServs = append(retServs, v.Server)
-		    continue
+			retServs = append(retServs, v.Server)
+			continue
 		}
 		score := v.Score(search)
 		if score < 0 {
@@ -90,10 +90,10 @@ func (c *Client) DiscoServers(ck *cookie.Cookie, search string) (*discotypes.Ser
 		retServs = append(retServs, v.Server)
 	}
 	if search != "" {
-	    sort.Slice(retServs, func(i, j int) bool {
-		    // lower score is better
-		    return retServs[i].Score < retServs[j].Score
-	    })
+		sort.Slice(retServs, func(i, j int) bool {
+			// lower score is better
+			return retServs[i].Score < retServs[j].Score
+		})
 	}
 	return &discotypes.Servers{
 		List: retServs,

--- a/client/discovery.go
+++ b/client/discovery.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/eduvpn/eduvpn-common/i18nerr"
@@ -34,10 +35,22 @@ func (c *Client) DiscoOrganizations(ck *cookie.Cookie, search string) (*discotyp
 	// convert to public subset
 	var retOrgs []discotypes.Organization
 	for _, v := range orgs.List {
-		if !v.Matches(search) {
+		if search == "" {
+		    retOrgs = append(retOrgs, v.Organization)
+		    continue
+		}
+		score := v.Score(search)
+		if score < 0 {
 			continue
 		}
+		v.Organization.Score = score
 		retOrgs = append(retOrgs, v.Organization)
+	}
+	if search != "" {
+	    sort.Slice(retOrgs, func(i, j int) bool {
+		    // lower score is better
+		    return retOrgs[i].Score < retOrgs[j].Score
+	    })
 	}
 	return &discotypes.Organizations{
 		List: retOrgs,
@@ -65,10 +78,22 @@ func (c *Client) DiscoServers(ck *cookie.Cookie, search string) (*discotypes.Ser
 	// convert to public subset
 	var retServs []discotypes.Server
 	for _, v := range servs.List {
-		if !v.Matches(search) {
+		if search == "" {
+		    retServs = append(retServs, v.Server)
+		    continue
+		}
+		score := v.Score(search)
+		if score < 0 {
 			continue
 		}
+		v.Server.Score = score
 		retServs = append(retServs, v.Server)
+	}
+	if search != "" {
+	    sort.Slice(retServs, func(i, j int) bool {
+		    // lower score is better
+		    return retServs[i].Score < retServs[j].Score
+	    })
 	}
 	return &discotypes.Servers{
 		List: retServs,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -173,11 +173,11 @@ func printConfig(url string, srvType srvtypes.Type) {
 	_ = c.Register()
 
 	ck := cookie.NewWithContext(context.Background())
-	_, err = c.DiscoOrganizations(ck)
+	_, err = c.DiscoOrganizations(ck, "")
 	if err != nil {
 		panic(err)
 	}
-	_, err = c.DiscoServers(ck)
+	_, err = c.DiscoServers(ck, "")
 	if err != nil {
 		panic(err)
 	}

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -305,14 +305,12 @@ Example Input: ```DiscoOrganizations(myCookie, "")```
 Example Output:
 
     {
-     "v": 1695291170,
      "organization_list": [
        {
          "display_name": {
            "en": "Academic Network of Albania - RASH"
          },
          "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
-         "secure_internet_home": "https://eduvpn.rash.al/"
        },
        {
          "display_name": {
@@ -320,7 +318,6 @@ Example Output:
            "en": "Danish Language Council"
          },
          "org_id": "http://idp.dsn.dk/adfs/services/trust",
-         "secure_internet_home": "https://eduvpn.deic.dk/"
        },
        {
          "display_name": {
@@ -328,24 +325,22 @@ Example Output:
            "en": "Business Academy Aarhus"
          },
          "org_id": "http://adfs.eaaa.dk/adfs/services/trust",
-         "secure_inte .....................
     }, null
 
 Example Input: ```DiscoOrganizations(myCookie, "rash")```
 
 Example Output:
 
-    {
-     "v": 1695291170,
-     "organization_list": [
-       {
-         "display_name": {
-           "en": "Academic Network of Albania - RASH"
-         },
-         "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
-         "secure_internet_home": "https://eduvpn.rash.al/"
-       },
-    }, null
+    	{
+    	 "organization_list": [
+    	   {
+    	     "display_name": {
+    	       "en": "Academic Network of Albania - RASH"
+    	     },
+    	     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
+    	   },
+          ]
+    	}, null
 
 ## DiscoServers
 Signature:
@@ -370,25 +365,14 @@ Example Input: ```DiscoServers(myCookie, "")```
 Example Output:
 
     {
-     "v": 1695291170,
      "server_list": [
        {
          "base_url": "https://eduvpn.rash.al/",
-         "country_code": "AL",
-         "public_key_list": [
-           "k7.pub.S4j5JJiTEz1fWMkI.hzU_xJasWzD6Da2WR7hgbobx9n3o4XSDeqFh03tgM-0"
-         ],
          "server_type": "secure_internet",
-         "support_contact": [
-           "mailto:helpdesk@rash.al"
-         ]
        },
        {
          "base_url": "https://eduvpn.deic.dk/",
-         "country_code": "DK",
-         "public_key_list": [
-           "k7.pub.RNOJIYbemlfsE7EL.BxmV2l2UV7pCqz135ofBgyG9-xLg0R9rILQedZrfLtE"
-         ], ..................
+         "server_type": "secure_internet",
     } , null
 
 Example Input: ```DiscoServers(myCookie, "heanet")```
@@ -396,16 +380,13 @@ Example Input: ```DiscoServers(myCookie, "heanet")```
 Example Output:
 
     	{
-    	 "v": 1695291170,
     	 "server_list": [
              {
                "base_url": "https://eduvpn.heanet.ie/",
-               "display_name": "HEAnet Staff",
+               "display_name": {
+                 "en": "HEAnet Staff"
+                },
                "server_type": "institute_access",
-               "support_contact": [
-                 "mailto:noc@heanet.ie",
-                 "tel:+35316609040"
-               ]
              },
            ]
     	} , null

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -286,19 +286,21 @@ Example Output:
 ## DiscoOrganizations
 Signature:
  ```go
-func DiscoOrganizations(c C.uintptr_t) (*C.char, *C.char)
+func DiscoOrganizations(c C.uintptr_t, search *C.char) (*C.char, *C.char)
 ```
 DiscoOrganizations gets the organizations from discovery, returned as
 types/discovery/discovery.go Organizations marshalled as JSON
 
 `c` is the Cookie that needs to be passed. Create a new Cookie using
-`CookieNew`
+`CookieNew` `search` is the search string for filtering the list. It checks
+for keywords and display name case insensitive as a substring matching.
+If search is empty it returns ALL organizations currently known in common
 
 If it was unsuccessful, it returns an error. Note that when the lib was
 built in release mode the data is almost always non-nil, even when an error
 has occurred This means it has just returned the cached list
 
-Example Input: ```DiscoOrganizations(myCookie)```
+Example Input: ```DiscoOrganizations(myCookie, "")```
 
 Example Output:
 
@@ -329,22 +331,41 @@ Example Output:
          "secure_inte .....................
     }, null
 
+Example Input: ```DiscoOrganizations(myCookie, "rash")```
+
+Example Output:
+
+    {
+     "v": 1695291170,
+     "organization_list": [
+       {
+         "display_name": {
+           "en": "Academic Network of Albania - RASH"
+         },
+         "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
+         "secure_internet_home": "https://eduvpn.rash.al/"
+       },
+    }, null
+
 ## DiscoServers
 Signature:
  ```go
-func DiscoServers(c C.uintptr_t) (*C.char, *C.char)
+func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char)
 ```
 DiscoServers gets the servers from discovery, returned as
 types/discovery/discovery.go Servers marshalled as JSON
 
 `c` is the Cookie that needs to be passed. Create a new Cookie using
-`CookieNew`
+`CookieNew` `search` is the search string for filtering the list. It checks
+for keywords and display name case insensitive as a substring matching.
+If search is empty it returns ALL servers currently known in common,
+including secure internet servers that do not have a display name set
 
 If it was unsuccessful, it returns an error. Note that when the lib was
 built in release mode the data is almost always non-nil, even when an error
 has occurred This means it has just returned the cached list
 
-Example Input: ```DiscoServers(myCookie)```
+Example Input: ```DiscoServers(myCookie, "")```
 
 Example Output:
 
@@ -369,6 +390,25 @@ Example Output:
            "k7.pub.RNOJIYbemlfsE7EL.BxmV2l2UV7pCqz135ofBgyG9-xLg0R9rILQedZrfLtE"
          ], ..................
     } , null
+
+Example Input: ```DiscoServers(myCookie, "heanet")```
+
+Example Output:
+
+    	{
+    	 "v": 1695291170,
+    	 "server_list": [
+             {
+               "base_url": "https://eduvpn.heanet.ie/",
+               "display_name": "HEAnet Staff",
+               "server_type": "institute_access",
+               "support_contact": [
+                 "mailto:noc@heanet.ie",
+                 "tel:+35316609040"
+               ]
+             },
+           ]
+    	} , null
 
 ## ExpiryTimes
 Signature:

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -292,8 +292,10 @@ DiscoOrganizations gets the organizations from discovery, returned as
 types/discovery/discovery.go Organizations marshalled as JSON
 
 `c` is the Cookie that needs to be passed. Create a new Cookie using
-`CookieNew` `search` is the search string for filtering the list. It checks
-for keywords and display name case insensitive as a substring matching.
+`CookieNew` `search` is the search string for filtering the list. If any of
+the words in the search query is not contained in any of the display names
+or keywords, the candidate is filtered. Otherwise they are ranked based on
+the levenshtein distance: https://en.wikipedia.org/wiki/Levenshtein_distance
 If search is empty it returns ALL organizations currently known in common
 
 If it was unsuccessful, it returns an error. Note that when the lib was
@@ -351,10 +353,10 @@ DiscoServers gets the servers from discovery, returned as
 types/discovery/discovery.go Servers marshalled as JSON
 
 `c` is the Cookie that needs to be passed. Create a new Cookie using
-`CookieNew` `search` is the search string for filtering the list. It checks
-for keywords and display name case insensitive as a substring matching.
-If search is empty it returns ALL servers currently known in common,
-including secure internet servers that do not have a display name set
+`CookieNew` `search` is the search string for filtering the list. If any of
+the words in the search query is not contained in any of the display names
+or keywords, the candidate is filtered. Otherwise they are ranked based on
+the levenshtein distance: https://en.wikipedia.org/wiki/Levenshtein_distance
 
 If it was unsuccessful, it returns an error. Note that when the lib was
 built in release mode the data is almost always non-nil, even when an error
@@ -364,16 +366,18 @@ Example Input: ```DiscoServers(myCookie, "")```
 
 Example Output:
 
-    {
-     "server_list": [
-       {
-         "base_url": "https://eduvpn.rash.al/",
-         "server_type": "secure_internet",
-       },
-       {
-         "base_url": "https://eduvpn.deic.dk/",
-         "server_type": "secure_internet",
-    } , null
+    	{
+    	 "server_list": [
+    	   {
+    	     "base_url": "https://eduvpn.rash.al/",
+              "country_code": "AL",
+    	     "server_type": "secure_internet",
+    	   },
+    	   {
+    	     "base_url": "https://eduvpn.deic.dk/",
+              "country_code": "DK",
+    	     "server_type": "secure_internet",
+    	} , null
 
 Example Input: ```DiscoServers(myCookie, "heanet")```
 

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -687,17 +687,17 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 //
 // Example Output:
 //
-//	{
-//	 "server_list": [
-//          {
-//            "base_url": "https://eduvpn.heanet.ie/",
-//            "display_name": {
-//              "en": "HEAnet Staff"
-//             },
-//            "server_type": "institute_access",
-//          },
-//        ]
-//	} , null
+//		{
+//		 "server_list": [
+//	         {
+//	           "base_url": "https://eduvpn.heanet.ie/",
+//	           "display_name": {
+//	             "en": "HEAnet Staff"
+//	            },
+//	           "server_type": "institute_access",
+//	         },
+//	       ]
+//		} , null
 //
 //export DiscoServers
 func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
@@ -759,17 +759,16 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 //
 // Example Output:
 //
-//	{
-//	 "organization_list": [
-//	   {
-//	     "display_name": {
-//	       "en": "Academic Network of Albania - RASH"
-//	     },
-//	     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
-//	   },
-//       ]
-//	}, null
-//
+//		{
+//		 "organization_list": [
+//		   {
+//		     "display_name": {
+//		       "en": "Academic Network of Albania - RASH"
+//		     },
+//		     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
+//		   },
+//	      ]
+//		}, null
 //
 //export DiscoOrganizations
 func DiscoOrganizations(c C.uintptr_t, search *C.char) (*C.char, *C.char) {

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -663,7 +663,9 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 // DiscoServers gets the servers from discovery, returned as types/discovery/discovery.go Servers marshalled as JSON
 //
 // `c` is the Cookie that needs to be passed. Create a new Cookie using `CookieNew`
-// `search` is the search string for filtering the list. It checks for keywords and display name case insensitive as a substring matching. If search is empty it returns ALL servers currently known in common, including secure internet servers that do not have a display name set
+// `search` is the search string for filtering the list.
+// If any of the words in the search query is not contained in any of the display names or keywords, the candidate is filtered.
+// Otherwise they are ranked based on the levenshtein distance: https://en.wikipedia.org/wiki/Levenshtein_distance 
 //
 // If it was unsuccessful, it returns an error. Note that when the lib was built in release mode the data is almost always non-nil, even when an error has occurred
 // This means it has just returned the cached list
@@ -676,10 +678,12 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 //	 "server_list": [
 //	   {
 //	     "base_url": "https://eduvpn.rash.al/",
+//           "country_code": "AL",
 //	     "server_type": "secure_internet",
 //	   },
 //	   {
 //	     "base_url": "https://eduvpn.deic.dk/",
+//           "country_code": "DK",
 //	     "server_type": "secure_internet",
 //	} , null
 //
@@ -723,7 +727,10 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 // DiscoOrganizations gets the organizations from discovery, returned as types/discovery/discovery.go Organizations marshalled as JSON
 //
 // `c` is the Cookie that needs to be passed. Create a new Cookie using `CookieNew`
-// `search` is the search string for filtering the list. It checks for keywords and display name case insensitive as a substring matching. If search is empty it returns ALL organizations currently known in common
+// `search` is the search string for filtering the list.
+// If any of the words in the search query is not contained in any of the display names or keywords, the candidate is filtered.
+// Otherwise they are ranked based on the levenshtein distance: https://en.wikipedia.org/wiki/Levenshtein_distance 
+// If search is empty it returns ALL organizations currently known in common
 //
 // If it was unsuccessful, it returns an error. Note that when the lib was built in release mode the data is almost always non-nil, even when an error has occurred
 // This means it has just returned the cached list

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -663,11 +663,12 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 // DiscoServers gets the servers from discovery, returned as types/discovery/discovery.go Servers marshalled as JSON
 //
 // `c` is the Cookie that needs to be passed. Create a new Cookie using `CookieNew`
+// `search` is the search string for filtering the list. It checks for keywords and display name case insensitive as a substring matching. If search is empty it returns ALL servers currently known in common, including secure internet servers that do not have a display name set
 //
 // If it was unsuccessful, it returns an error. Note that when the lib was built in release mode the data is almost always non-nil, even when an error has occurred
 // This means it has just returned the cached list
 //
-// Example Input: ```DiscoServers(myCookie)```
+// Example Input: ```DiscoServers(myCookie, "")```
 //
 // Example Output:
 //
@@ -693,8 +694,27 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 //	     ], ..................
 //	} , null
 //
+// Example Input: ```DiscoServers(myCookie, "heanet")```
+//
+// Example Output:
+//
+//	{
+//	 "v": 1695291170,
+//	 "server_list": [
+//          {
+//            "base_url": "https://eduvpn.heanet.ie/",
+//            "display_name": "HEAnet Staff",
+//            "server_type": "institute_access",
+//            "support_contact": [
+//              "mailto:noc@heanet.ie",
+//              "tel:+35316609040"
+//            ]
+//          },
+//        ]
+//	} , null
+//
 //export DiscoServers
-func DiscoServers(c C.uintptr_t) (*C.char, *C.char) {
+func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 	state, stateErr := getVPNState()
 	if stateErr != nil {
 		return nil, getCError(stateErr)
@@ -703,7 +723,7 @@ func DiscoServers(c C.uintptr_t) (*C.char, *C.char) {
 	if err != nil {
 		return nil, getCError(err)
 	}
-	servers, err := state.DiscoServers(ck)
+	servers, err := state.DiscoServers(ck, C.GoString(search))
 	if servers == nil && err != nil {
 		return nil, getCError(err)
 	}
@@ -717,11 +737,12 @@ func DiscoServers(c C.uintptr_t) (*C.char, *C.char) {
 // DiscoOrganizations gets the organizations from discovery, returned as types/discovery/discovery.go Organizations marshalled as JSON
 //
 // `c` is the Cookie that needs to be passed. Create a new Cookie using `CookieNew`
+// `search` is the search string for filtering the list. It checks for keywords and display name case insensitive as a substring matching. If search is empty it returns ALL organizations currently known in common
 //
 // If it was unsuccessful, it returns an error. Note that when the lib was built in release mode the data is almost always non-nil, even when an error has occurred
 // This means it has just returned the cached list
 //
-// Example Input: ```DiscoOrganizations(myCookie)```
+// Example Input: ```DiscoOrganizations(myCookie, "")```
 //
 // Example Output:
 //
@@ -752,8 +773,25 @@ func DiscoServers(c C.uintptr_t) (*C.char, *C.char) {
 //	     "secure_inte .....................
 //	}, null
 //
+// Example Input: ```DiscoOrganizations(myCookie, "rash")```
+//
+// Example Output:
+//
+//	{
+//	 "v": 1695291170,
+//	 "organization_list": [
+//	   {
+//	     "display_name": {
+//	       "en": "Academic Network of Albania - RASH"
+//	     },
+//	     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
+//	     "secure_internet_home": "https://eduvpn.rash.al/"
+//	   },
+//	}, null
+//
+//
 //export DiscoOrganizations
-func DiscoOrganizations(c C.uintptr_t) (*C.char, *C.char) {
+func DiscoOrganizations(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 	state, stateErr := getVPNState()
 	if stateErr != nil {
 		return nil, getCError(stateErr)
@@ -762,7 +800,7 @@ func DiscoOrganizations(c C.uintptr_t) (*C.char, *C.char) {
 	if err != nil {
 		return nil, getCError(err)
 	}
-	orgs, err := state.DiscoOrganizations(ck)
+	orgs, err := state.DiscoOrganizations(ck, C.GoString(search))
 	if orgs == nil && err != nil {
 		return nil, getCError(err)
 	}

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -673,25 +673,14 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 // Example Output:
 //
 //	{
-//	 "v": 1695291170,
 //	 "server_list": [
 //	   {
 //	     "base_url": "https://eduvpn.rash.al/",
-//	     "country_code": "AL",
-//	     "public_key_list": [
-//	       "k7.pub.S4j5JJiTEz1fWMkI.hzU_xJasWzD6Da2WR7hgbobx9n3o4XSDeqFh03tgM-0"
-//	     ],
 //	     "server_type": "secure_internet",
-//	     "support_contact": [
-//	       "mailto:helpdesk@rash.al"
-//	     ]
 //	   },
 //	   {
 //	     "base_url": "https://eduvpn.deic.dk/",
-//	     "country_code": "DK",
-//	     "public_key_list": [
-//	       "k7.pub.RNOJIYbemlfsE7EL.BxmV2l2UV7pCqz135ofBgyG9-xLg0R9rILQedZrfLtE"
-//	     ], ..................
+//	     "server_type": "secure_internet",
 //	} , null
 //
 // Example Input: ```DiscoServers(myCookie, "heanet")```
@@ -699,16 +688,13 @@ func SetSecureLocation(orgID *C.char, cc *C.char) *C.char {
 // Example Output:
 //
 //	{
-//	 "v": 1695291170,
 //	 "server_list": [
 //          {
 //            "base_url": "https://eduvpn.heanet.ie/",
-//            "display_name": "HEAnet Staff",
+//            "display_name": {
+//              "en": "HEAnet Staff"
+//             },
 //            "server_type": "institute_access",
-//            "support_contact": [
-//              "mailto:noc@heanet.ie",
-//              "tel:+35316609040"
-//            ]
 //          },
 //        ]
 //	} , null
@@ -747,14 +733,12 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 // Example Output:
 //
 //	{
-//	 "v": 1695291170,
 //	 "organization_list": [
 //	   {
 //	     "display_name": {
 //	       "en": "Academic Network of Albania - RASH"
 //	     },
 //	     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
-//	     "secure_internet_home": "https://eduvpn.rash.al/"
 //	   },
 //	   {
 //	     "display_name": {
@@ -762,7 +746,6 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 //	       "en": "Danish Language Council"
 //	     },
 //	     "org_id": "http://idp.dsn.dk/adfs/services/trust",
-//	     "secure_internet_home": "https://eduvpn.deic.dk/"
 //	   },
 //	   {
 //	     "display_name": {
@@ -770,7 +753,6 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 //	       "en": "Business Academy Aarhus"
 //	     },
 //	     "org_id": "http://adfs.eaaa.dk/adfs/services/trust",
-//	     "secure_inte .....................
 //	}, null
 //
 // Example Input: ```DiscoOrganizations(myCookie, "rash")```
@@ -778,15 +760,14 @@ func DiscoServers(c C.uintptr_t, search *C.char) (*C.char, *C.char) {
 // Example Output:
 //
 //	{
-//	 "v": 1695291170,
 //	 "organization_list": [
 //	   {
 //	     "display_name": {
 //	       "en": "Academic Network of Albania - RASH"
 //	     },
 //	     "org_id": "https://idp.rash.al/simplesaml/saml2/idp/metadata.php",
-//	     "secure_internet_home": "https://eduvpn.rash.al/"
 //	   },
+//       ]
 //	}, null
 //
 //

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/eduvpn/eduvpn-common/internal/http"
+	"github.com/eduvpn/eduvpn-common/internal/levenshtein"
 	"github.com/eduvpn/eduvpn-common/internal/log"
 	"github.com/eduvpn/eduvpn-common/internal/verify"
 	discotypes "github.com/eduvpn/eduvpn-common/types/discovery"
@@ -40,20 +40,8 @@ type Organization struct {
 	KeywordList discotypes.MapOrString `json:"keyword_list,omitempty"`
 }
 
-// Matches returns if the search query `str` matches with this organization
-func (s *Organization) Matches(str string) bool {
-	var catalog strings.Builder
-	for _, v := range s.DisplayName {
-		// length and nil error is returned
-		_, _ = catalog.WriteString(strings.ToLower(v))
-		_, _ = catalog.WriteString(" ")
-	}
-	for _, v := range s.KeywordList {
-		// length and nil error is returned
-		_, _ = catalog.WriteString(strings.ToLower(v))
-		_, _ = catalog.WriteString(" ")
-	}
-	return strings.Contains(catalog.String(), strings.ToLower(str))
+func (o *Organization) Score(search string) int {
+	return levenshtein.DiscoveryScore(search, o.DisplayName, o.KeywordList)
 }
 
 // Servers are the list of servers from https://disco.eduvpn.org/v2/server_list.json
@@ -82,19 +70,8 @@ type Server struct {
 }
 
 // Matches returns if the search query `str` matches with this server
-func (s *Server) Matches(str string) bool {
-	var catalog strings.Builder
-	for _, v := range s.DisplayName {
-		// length and nil error is returned
-		_, _ = catalog.WriteString(strings.ToLower(v))
-		_, _ = catalog.WriteString(" ")
-	}
-	for _, v := range s.KeywordList {
-		// length and nil error is returned
-		_, _ = catalog.WriteString(strings.ToLower(v))
-		_, _ = catalog.WriteString(" ")
-	}
-	return strings.Contains(catalog.String(), strings.ToLower(str))
+func (s *Server) Score(search string) int {
+	return levenshtein.DiscoveryScore(search, s.DisplayName, s.KeywordList)
 }
 
 // Discovery is the main structure used for this package.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -53,7 +53,7 @@ func (s *Organization) Matches(str string) bool {
 		_, _ = catalog.WriteString(strings.ToLower(v))
 		_, _ = catalog.WriteString(" ")
 	}
-	return strings.Contains(catalog.String(), str)
+	return strings.Contains(catalog.String(), strings.ToLower(str))
 }
 
 // Servers are the list of servers from https://disco.eduvpn.org/v2/server_list.json
@@ -96,7 +96,7 @@ func (s *Server) Matches(str string) bool {
 		_, _ = catalog.WriteString(strings.ToLower(v))
 		_, _ = catalog.WriteString(" ")
 	}
-	return strings.Contains(catalog.String(), str)
+	return strings.Contains(catalog.String(), strings.ToLower(str))
 }
 
 // Discovery is the main structure used for this package.

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -73,8 +73,6 @@ type Server struct {
 	discotypes.Server
 	// AuthenticationURLTemplate is the template to be used for authentication to skip WAYF
 	AuthenticationURLTemplate string `json:"authentication_url_template,omitempty"`
-	// CountryCode is the country code for the server in case of secure internet, e.g. NL
-	CountryCode string `json:"country_code,omitempty"`
 	// KeywordList are the keywords of the server, omitted if empty
 	KeywordList discotypes.MapOrString `json:"keyword_list,omitempty"`
 	// PublicKeyList are the public keys of the server. Currently not used in this lib but returned by the upstream discovery server

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/eduvpn/eduvpn-common/internal/http"
@@ -34,6 +35,25 @@ type Organization struct {
 	// SecureInternetHome is the secure internet home server that belongs to this organization
 	// Omitted if none is defined
 	SecureInternetHome string `json:"secure_internet_home"`
+	// KeywordList is the list of keywords
+	// Omitted if none is defined
+	KeywordList discotypes.MapOrString `json:"keyword_list,omitempty"`
+}
+
+// Matches returns if the search query `str` matches with this organization
+func (s *Organization) Matches(str string) bool {
+	var catalog strings.Builder
+	for _, v := range s.DisplayName {
+		// length and nil error is returned
+		_, _ = catalog.WriteString(strings.ToLower(v))
+		_, _ = catalog.WriteString(" ")
+	}
+	for _, v := range s.KeywordList {
+		// length and nil error is returned
+		_, _ = catalog.WriteString(strings.ToLower(v))
+		_, _ = catalog.WriteString(" ")
+	}
+	return strings.Contains(catalog.String(), str)
 }
 
 // Servers are the list of servers from https://disco.eduvpn.org/v2/server_list.json
@@ -55,10 +75,28 @@ type Server struct {
 	AuthenticationURLTemplate string `json:"authentication_url_template,omitempty"`
 	// CountryCode is the country code for the server in case of secure internet, e.g. NL
 	CountryCode string `json:"country_code,omitempty"`
+	// KeywordList are the keywords of the server, omitted if empty
+	KeywordList discotypes.MapOrString `json:"keyword_list,omitempty"`
 	// PublicKeyList are the public keys of the server. Currently not used in this lib but returned by the upstream discovery server
 	PublicKeyList []string `json:"public_key_list,omitempty"`
 	// SupportContact is the list/slice of support contacts
 	SupportContact []string `json:"support_contact,omitempty"`
+}
+
+// Matches returns if the search query `str` matches with this server
+func (s *Server) Matches(str string) bool {
+	var catalog strings.Builder
+	for _, v := range s.DisplayName {
+		// length and nil error is returned
+		_, _ = catalog.WriteString(strings.ToLower(v))
+		_, _ = catalog.WriteString(" ")
+	}
+	for _, v := range s.KeywordList {
+		// length and nil error is returned
+		_, _ = catalog.WriteString(strings.ToLower(v))
+		_, _ = catalog.WriteString(" ")
+	}
+	return strings.Contains(catalog.String(), str)
 }
 
 // Discovery is the main structure used for this package.

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -90,12 +90,12 @@ func TestSecureLocationList(t *testing.T) {
 			Version: 1,
 			List: []Server{
 				// institute access server, this should not be found
-				{CountryCode: "", Type: "institute_access"},
+				{Server: discotypes.Server{Type: "institute_access"}, CountryCode: ""},
 				// secure internet servers, these should be found
-				{CountryCode: "b", Type: "secure_internet"},
-				{CountryCode: "c", Type: "secure_internet"},
+				{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "b"},
+				{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "c"},
 				// Unexpected type, this should not be found
-				{CountryCode: "d", Type: "test"},
+				{Server: discotypes.Server{Type: "test"}, CountryCode: "d"},
 			},
 		},
 	}
@@ -115,11 +115,11 @@ func TestServerByURL(t *testing.T) {
 			Version: 1,
 			List: []Server{
 				// institute access server
-				Server{BaseURL: "a", Type: "institute_access"},
+				{Server: discotypes.Server{BaseURL: "a", Type: "institute_access"}},
 				// secure internet servers
-				Server{BaseURL: "b", Type: "secure_internet"},
+				{Server: discotypes.Server{BaseURL: "b", Type: "secure_internet"}},
 				// Unexpected type, this should not be found
-				Server{BaseURL: "d", Type: "test"},
+				{Server: discotypes.Server{BaseURL: "d", Type: "test"}},
 			},
 		},
 	}
@@ -150,16 +150,16 @@ func TestServerByURL(t *testing.T) {
 
 // TestServerByCountryCode tests the function for getting a server by the country code
 func TestServerByCountryCode(t *testing.T) {
-	s1 := discotypes.Server{CountryCode: "a", Type: "secure_internet"}
+	s1 := Server{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "a"}
 	d := Discovery{
-		ServerList: discotypes.Servers{
+		ServerList: Servers{
 			Version: 1,
-			List: []discotypes.Server{
+			List: []Server{
 				// secure internet server
 				s1,
 				// Unexpected types, these should not be found
-				{CountryCode: "b", Type: "institute_access"},
-				{CountryCode: "c", Type: "test"},
+				{Server: discotypes.Server{Type: "institute_access"}, CountryCode: "b"},
+				{Server: discotypes.Server{Type: "test"}, CountryCode: "c"},
 			},
 		},
 	}
@@ -187,10 +187,10 @@ func TestServerByCountryCode(t *testing.T) {
 func TestOrgByID(t *testing.T) {
 	o1 := discotypes.Organization{OrgID: "a"}
 	d := Discovery{
-		OrganizationList: discotypes.Organizations{
+		OrganizationList: Organizations{
 			Version: 1,
-			List: []discotypes.Organization{
-				o1,
+			List: []Organization{
+				{Organization: o1},
 			},
 		},
 	}
@@ -209,21 +209,21 @@ func TestOrgByID(t *testing.T) {
 
 // TestSecureHomeArgs tests the function for getting an organization and matching secure internet server by organization ID
 func TestSecureHomeArgs(t *testing.T) {
-	o1 := discotypes.Organization{OrgID: "id", SecureInternetHome: "a"}
+	o1 := Organization{Organization: discotypes.Organization{OrgID: "id"}, SecureInternetHome: "a"}
 	s1 := discotypes.Server{BaseURL: "a", Type: "secure_internet"}
 	d := Discovery{
-		OrganizationList: discotypes.Organizations{
+		OrganizationList: Organizations{
 			Version: 1,
-			List: []discotypes.Organization{
-				{OrgID: "id2", SecureInternetHome: "c"},
+			List: []Organization{
+				{Organization: discotypes.Organization{OrgID: "id2"}, SecureInternetHome: "c"},
 				o1,
 			},
 		},
-		ServerList: discotypes.Servers{
+		ServerList: Servers{
 			Version: 1,
-			List: []discotypes.Server{
-				s1,
-				{BaseURL: "b"},
+			List: []Server{
+				{Server: s1},
+				{Server: discotypes.Server{BaseURL: "b"}},
 			},
 		},
 	}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -86,9 +86,9 @@ func TestOrganizations(t *testing.T) {
 // TestSecureLocationList tests the function for getting a list of secure internet servers
 func TestSecureLocationList(t *testing.T) {
 	d := Discovery{
-		ServerList: discotypes.Servers{
+		ServerList: Servers{
 			Version: 1,
-			List: []discotypes.Server{
+			List: []Server{
 				// institute access server, this should not be found
 				{CountryCode: "", Type: "institute_access"},
 				// secure internet servers, these should be found
@@ -111,15 +111,15 @@ func TestSecureLocationList(t *testing.T) {
 // TestServerByURL tests the function for getting a server by the Base URL and type
 func TestServerByURL(t *testing.T) {
 	d := Discovery{
-		ServerList: discotypes.Servers{
+		ServerList: Servers{
 			Version: 1,
-			List: []discotypes.Server{
+			List: []Server{
 				// institute access server
-				{BaseURL: "a", Type: "institute_access"},
+				Server{BaseURL: "a", Type: "institute_access"},
 				// secure internet servers
-				{BaseURL: "b", Type: "secure_internet"},
+				Server{BaseURL: "b", Type: "secure_internet"},
 				// Unexpected type, this should not be found
-				{BaseURL: "d", Type: "test"},
+				Server{BaseURL: "d", Type: "test"},
 			},
 		},
 	}

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -90,12 +90,12 @@ func TestSecureLocationList(t *testing.T) {
 			Version: 1,
 			List: []Server{
 				// institute access server, this should not be found
-				{Server: discotypes.Server{Type: "institute_access"}, CountryCode: ""},
+				{Server: discotypes.Server{Type: "institute_access"}},
 				// secure internet servers, these should be found
-				{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "b"},
-				{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "c"},
+				{Server: discotypes.Server{Type: "secure_internet", CountryCode: "b"}},
+				{Server: discotypes.Server{Type: "secure_internet", CountryCode: "c"}},
 				// Unexpected type, this should not be found
-				{Server: discotypes.Server{Type: "test"}, CountryCode: "d"},
+				{Server: discotypes.Server{Type: "test", CountryCode: "d"}},
 			},
 		},
 	}
@@ -150,7 +150,7 @@ func TestServerByURL(t *testing.T) {
 
 // TestServerByCountryCode tests the function for getting a server by the country code
 func TestServerByCountryCode(t *testing.T) {
-	s1 := Server{Server: discotypes.Server{Type: "secure_internet"}, CountryCode: "a"}
+	s1 := Server{Server: discotypes.Server{Type: "secure_internet", CountryCode: "a"}}
 	d := Discovery{
 		ServerList: Servers{
 			Version: 1,
@@ -158,8 +158,8 @@ func TestServerByCountryCode(t *testing.T) {
 				// secure internet server
 				s1,
 				// Unexpected types, these should not be found
-				{Server: discotypes.Server{Type: "institute_access"}, CountryCode: "b"},
-				{Server: discotypes.Server{Type: "test"}, CountryCode: "c"},
+				{Server: discotypes.Server{Type: "institute_access", CountryCode: "b"}},
+				{Server: discotypes.Server{Type: "test", CountryCode: "c"}},
 			},
 		},
 	}

--- a/internal/levenshtein/levenshtein.go
+++ b/internal/levenshtein/levenshtein.go
@@ -58,9 +58,9 @@ func levenshtein(os, ot string) int {
 func adjusted(substr, full string) int {
 	substr = normalize(substr)
 	full = normalize(full)
-	s_sub := strings.Split(substr, " ")
-	for _, v_sub := range s_sub {
-		if !strings.Contains(full, v_sub) {
+	sSub := strings.Split(substr, " ")
+	for _, vSub := range sSub {
+		if !strings.Contains(full, vSub) {
 			return -1
 		}
 	}

--- a/internal/levenshtein/levenshtein.go
+++ b/internal/levenshtein/levenshtein.go
@@ -1,0 +1,117 @@
+package levenshtein
+
+import (
+	"unicode/utf8"
+	"unicode"
+	"strings"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// min returns the min of a and b
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// levenshtein is an algorithm that returns the "distance" between two strings
+// the distance for hello and helloxd is 2 because it takes two inserts to go from hello to helloxd
+// the distance between hello and hello is 0 because the strings are equal
+// apart from insertions, the levenshtein algorithm also takes substitutions and deletions into account
+// levenshtein implementation from https://en.wikipedia.org/wiki/Levenshtein_distance#Iterative_with_two_matrix_rows
+func levenshtein(os, ot string) int {
+	n := utf8.RuneCountInString(os)
+	m := utf8.RuneCountInString(ot)
+	s := []rune(os)
+	t := []rune(ot)
+	v0 := make([]int, m+1)
+	v1 := make([]int, m+1)
+	for i := 0; i <= m; i++ {
+		v0[i] = i
+	}
+
+	for i := 0; i < n; i++ {
+		v1[0] = i + 1
+		for j := 0; j < m; j++ {
+			dc := v0[j+1] + 1
+			ic := v1[j] + 1
+			var sc int
+			if s[i] == t[j] {
+				sc = v0[j]
+			} else {
+				sc = v0[j] + 1
+			}
+			v1[j+1] = min(min(dc, ic), sc)
+		}
+		v0, v1 = v1, v0
+	}
+	return v0[m]
+}
+
+// adjusted creates and adjusted version of the levenshtein algorithm
+// where it filters entries where one of the words in the substr is not contained in `full`
+// for these a score of -1 returned
+// for all others it is the normal levenshtein distance
+func adjusted(substr, full string) int {
+	substr = normalize(substr)
+	full = normalize(full)
+	s_sub := strings.Split(substr, " ")
+	for _, v_sub := range s_sub {
+		if !strings.Contains(full, v_sub) {
+			return -1
+		}
+	}
+	return levenshtein(substr, full)
+}
+
+// KeywordPenalty is the penalty for matching on keywords instead of display names
+const KeywordPenalty = 2
+
+// DiscoveryScore computes the score of a discovery entry with the given search query
+// a negative score means exclude the entry from the results
+func DiscoveryScore(search string, displays map[string]string, keywords map[string]string) int {
+	var catalogDN strings.Builder
+	for _, v := range displays {
+		// length and nil error is returned
+		_, _ = catalogDN.WriteString(v)
+	}
+	scoreDN := adjusted(search, catalogDN.String())
+	var catalogKW strings.Builder
+	for _, v := range keywords {
+		// length and nil error is returned
+		_, _ = catalogKW.WriteString(v)
+	}
+	scoreKW := 3*adjusted(search, catalogKW.String())
+
+	// if both scores are positive, return the min
+	if scoreDN >= 0 && scoreKW >= 0 {
+		return min(scoreDN, scoreKW)
+	}
+
+	// scoreKW is negative, return scoreDN
+	if scoreDN >= 0 {
+		return scoreDN
+	}
+	// scoreDN is negative, return scoreKW
+	return scoreKW
+}
+
+// removeDiacritics removes "diacritics" :^)
+// diacritics are special characters, e.g. GÉANT, becomes GEANT
+func removeDiacritics(text string) (string, error) {
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	result, _, err := transform.String(t, text)
+	if err != nil {
+		return text, err
+	}
+	return result, nil
+}
+
+// normalize removes diacritics and converts to lower case
+func normalize(text string) string {
+	dt, _ := removeDiacritics(text)
+	return strings.ToLower(dt)
+}

--- a/internal/levenshtein/levenshtein.go
+++ b/internal/levenshtein/levenshtein.go
@@ -34,12 +34,14 @@ func levenshtein(os, ot string) int {
 		v0[i] = i
 	}
 
+	// loop through every word in the first string
 	for i := 0; i < n; i++ {
 		v1[0] = i + 1
 		for j := 0; j < m; j++ {
 			// calculate deletion cost,
 			// insertion cost and
-			// substitution cost
+			// substitution cost to get from the string
+			// to the target
 			dc := v0[j+1] + 1
 			ic := v1[j] + 1
 			var sc int
@@ -71,6 +73,7 @@ func adjusted(substr, full string) int {
 }
 
 // KeywordPenalty is the penalty for matching on keywords instead of display names
+// We have a penalty for matching on keywords because currently there are a lot of generic keywords
 const KeywordPenalty = 2
 
 // DiscoveryScore computes the score of a discovery entry with the given search query

--- a/internal/levenshtein/levenshtein.go
+++ b/internal/levenshtein/levenshtein.go
@@ -1,9 +1,10 @@
 package levenshtein
 
 import (
-	"unicode/utf8"
-	"unicode"
 	"strings"
+	"unicode"
+	"unicode/utf8"
+
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
@@ -36,6 +37,9 @@ func levenshtein(os, ot string) int {
 	for i := 0; i < n; i++ {
 		v1[0] = i + 1
 		for j := 0; j < m; j++ {
+			// calculate deletion cost,
+			// insertion cost and
+			// substitution cost
 			dc := v0[j+1] + 1
 			ic := v1[j] + 1
 			var sc int
@@ -44,6 +48,7 @@ func levenshtein(os, ot string) int {
 			} else {
 				sc = v0[j] + 1
 			}
+			// take the min of all the costs
 			v1[j+1] = min(min(dc, ic), sc)
 		}
 		v0, v1 = v1, v0
@@ -84,7 +89,7 @@ func DiscoveryScore(search string, displays map[string]string, keywords map[stri
 		// length and nil error is returned
 		_, _ = catalogKW.WriteString(v)
 	}
-	scoreKW := 3*adjusted(search, catalogKW.String())
+	scoreKW := KeywordPenalty * adjusted(search, catalogKW.String())
 
 	// if both scores are positive, return the min
 	if scoreDN >= 0 && scoreKW >= 0 {

--- a/internal/levenshtein/levenshtein_test.go
+++ b/internal/levenshtein/levenshtein_test.go
@@ -3,163 +3,163 @@ package levenshtein
 import "testing"
 
 func TestLevenshtein(t *testing.T) {
-		cases := []struct{
-				a string
-				b string
-				score int
-		}{
-				{
-					a: "foo",
-					b: "foo",
-					score: 0,
-				},
-				{
-					a: "foo",
-					b: "foo",
-					score: 0,
-				},
-				{
-					a: "foo",
-					b: "foosd",
-					score: 2,
-				},
-				{
-					a: "foo",
-					b: "bla",
-					score: 3,
-				},
-				{
-					a: "foo",
-					b: "",
-					score: 3,
-				},
-				{
-					a: "",
-					b: "foo",
-					score: 3,
-				},
+	cases := []struct {
+		a     string
+		b     string
+		score int
+	}{
+		{
+			a:     "foo",
+			b:     "foo",
+			score: 0,
+		},
+		{
+			a:     "foo",
+			b:     "foo",
+			score: 0,
+		},
+		{
+			a:     "foo",
+			b:     "foosd",
+			score: 2,
+		},
+		{
+			a:     "foo",
+			b:     "bla",
+			score: 3,
+		},
+		{
+			a:     "foo",
+			b:     "",
+			score: 3,
+		},
+		{
+			a:     "",
+			b:     "foo",
+			score: 3,
+		},
+	}
+	for i, c := range cases {
+		g := levenshtein(c.a, c.b)
+		if g != c.score {
+			t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
 		}
-		for i, c := range cases {
-				g := levenshtein(c.a, c.b)
-				if g != c.score {
-						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
-				}
-		}
+	}
 }
 
 func TestAdjusted(t *testing.T) {
-		cases := []struct{
-				a string
-				b string
-				score int
-		}{
-				{
-					a: "foo",
-					b: "foo",
-					score: 0,
-				},
-				{
-					a: "foo",
-					b: "foo",
-					score: 0,
-				},
-				{
-					a: "foo",
-					b: "foosd",
-					score: 2,
-				},
-				{
-					a: "foo",
-					b: "bla",
-					score: -1,
-				},
-				{
-					a: "bla foo",
-					b: "bla",
-					score: -1,
-				},
-				{
-					a: "foo",
-					b: "",
-					score: -1,
-				},
-				{
-					a: "",
-					b: "foo",
-					score: 3,
-				},
+	cases := []struct {
+		a     string
+		b     string
+		score int
+	}{
+		{
+			a:     "foo",
+			b:     "foo",
+			score: 0,
+		},
+		{
+			a:     "foo",
+			b:     "foo",
+			score: 0,
+		},
+		{
+			a:     "foo",
+			b:     "foosd",
+			score: 2,
+		},
+		{
+			a:     "foo",
+			b:     "bla",
+			score: -1,
+		},
+		{
+			a:     "bla foo",
+			b:     "bla",
+			score: -1,
+		},
+		{
+			a:     "foo",
+			b:     "",
+			score: -1,
+		},
+		{
+			a:     "",
+			b:     "foo",
+			score: 3,
+		},
+	}
+	for i, c := range cases {
+		g := adjusted(c.a, c.b)
+		if g != c.score {
+			t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
 		}
-		for i, c := range cases {
-				g := adjusted(c.a, c.b)
-				if g != c.score {
-						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
-				}
-		}
+	}
 }
 
 func TestDiscoveryScore(t *testing.T) {
-		cases := []struct{
-				q string
-				disp map[string]string
-				keys map[string]string
-				score int
-		}{
-				{
-						q: "test",
-						disp: map[string]string{
-								"en": "test",
-								"de": "test",
-						},
-						keys: map[string]string{
-								"en": "testing",
-								"de": "testing",
-						},
-						score: 4,
-				},
-				{
-						q: "test",
-						disp: map[string]string{
-								"en": "testing",
-								"de": "testing",
-						},
-						keys: map[string]string{
-								"en": "test",
-								"de": "test",
-						},
-						score: 8,
-				},
-				{
-						q: "foo",
-						disp: map[string]string{
-								"en": "test",
-								"de": "testing",
-						},
-						keys: map[string]string{
-								"en": "foo",
-								"de": "foo",
-						},
-						score: 6,
-				},
-				{
-						q: "fox",
-						disp: map[string]string{
-								"en": "test",
-								"de": "testing",
-						},
-						keys: map[string]string{
-								"en": "foo",
-								"de": "foo",
-						},
-						score: -2,
-				},
-		}
+	cases := []struct {
+		q     string
+		disp  map[string]string
+		keys  map[string]string
+		score int
+	}{
+		{
+			q: "test",
+			disp: map[string]string{
+				"en": "test",
+				"de": "test",
+			},
+			keys: map[string]string{
+				"en": "testing",
+				"de": "testing",
+			},
+			score: 4,
+		},
+		{
+			q: "test",
+			disp: map[string]string{
+				"en": "testing",
+				"de": "testing",
+			},
+			keys: map[string]string{
+				"en": "test",
+				"de": "test",
+			},
+			score: 8,
+		},
+		{
+			q: "foo",
+			disp: map[string]string{
+				"en": "test",
+				"de": "testing",
+			},
+			keys: map[string]string{
+				"en": "foo",
+				"de": "foo",
+			},
+			score: 6,
+		},
+		{
+			q: "fox",
+			disp: map[string]string{
+				"en": "test",
+				"de": "testing",
+			},
+			keys: map[string]string{
+				"en": "foo",
+				"de": "foo",
+			},
+			score: -2,
+		},
+	}
 
-		for i, c := range cases {
-				g := DiscoveryScore(c.q, c.disp, c.keys)
-				if g != c.score {
-						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
-				}
+	for i, c := range cases {
+		g := DiscoveryScore(c.q, c.disp, c.keys)
+		if g != c.score {
+			t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
 		}
+	}
 }
 
 func TestRemoveDiacritics(t *testing.T) {
@@ -179,9 +179,9 @@ func TestRemoveDiacritics(t *testing.T) {
 			e:     nil,
 		},
 		{
-				input: "GÉANT",
-				want: "GEANT",
-				e: nil,
+			input: "GÉANT",
+			want:  "GEANT",
+			e:     nil,
 		},
 	}
 

--- a/internal/levenshtein/levenshtein_test.go
+++ b/internal/levenshtein/levenshtein_test.go
@@ -114,7 +114,7 @@ func TestDiscoveryScore(t *testing.T) {
 				"en": "testing",
 				"de": "testing",
 			},
-			score: 4,
+			score: 0,
 		},
 		{
 			q: "test",
@@ -126,7 +126,7 @@ func TestDiscoveryScore(t *testing.T) {
 				"en": "test",
 				"de": "test",
 			},
-			score: 8,
+			score: 2,
 		},
 		{
 			q: "foo",
@@ -138,7 +138,7 @@ func TestDiscoveryScore(t *testing.T) {
 				"en": "foo",
 				"de": "foo",
 			},
-			score: 6,
+			score: 2,
 		},
 		{
 			q: "fox",

--- a/internal/levenshtein/levenshtein_test.go
+++ b/internal/levenshtein/levenshtein_test.go
@@ -1,0 +1,194 @@
+package levenshtein
+
+import "testing"
+
+func TestLevenshtein(t *testing.T) {
+		cases := []struct{
+				a string
+				b string
+				score int
+		}{
+				{
+					a: "foo",
+					b: "foo",
+					score: 0,
+				},
+				{
+					a: "foo",
+					b: "foo",
+					score: 0,
+				},
+				{
+					a: "foo",
+					b: "foosd",
+					score: 2,
+				},
+				{
+					a: "foo",
+					b: "bla",
+					score: 3,
+				},
+				{
+					a: "foo",
+					b: "",
+					score: 3,
+				},
+				{
+					a: "",
+					b: "foo",
+					score: 3,
+				},
+		}
+		for i, c := range cases {
+				g := levenshtein(c.a, c.b)
+				if g != c.score {
+						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
+				}
+		}
+}
+
+func TestAdjusted(t *testing.T) {
+		cases := []struct{
+				a string
+				b string
+				score int
+		}{
+				{
+					a: "foo",
+					b: "foo",
+					score: 0,
+				},
+				{
+					a: "foo",
+					b: "foo",
+					score: 0,
+				},
+				{
+					a: "foo",
+					b: "foosd",
+					score: 2,
+				},
+				{
+					a: "foo",
+					b: "bla",
+					score: -1,
+				},
+				{
+					a: "bla foo",
+					b: "bla",
+					score: -1,
+				},
+				{
+					a: "foo",
+					b: "",
+					score: -1,
+				},
+				{
+					a: "",
+					b: "foo",
+					score: 3,
+				},
+		}
+		for i, c := range cases {
+				g := adjusted(c.a, c.b)
+				if g != c.score {
+						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
+				}
+		}
+}
+
+func TestDiscoveryScore(t *testing.T) {
+		cases := []struct{
+				q string
+				disp map[string]string
+				keys map[string]string
+				score int
+		}{
+				{
+						q: "test",
+						disp: map[string]string{
+								"en": "test",
+								"de": "test",
+						},
+						keys: map[string]string{
+								"en": "testing",
+								"de": "testing",
+						},
+						score: 4,
+				},
+				{
+						q: "test",
+						disp: map[string]string{
+								"en": "testing",
+								"de": "testing",
+						},
+						keys: map[string]string{
+								"en": "test",
+								"de": "test",
+						},
+						score: 8,
+				},
+				{
+						q: "foo",
+						disp: map[string]string{
+								"en": "test",
+								"de": "testing",
+						},
+						keys: map[string]string{
+								"en": "foo",
+								"de": "foo",
+						},
+						score: 6,
+				},
+				{
+						q: "fox",
+						disp: map[string]string{
+								"en": "test",
+								"de": "testing",
+						},
+						keys: map[string]string{
+								"en": "foo",
+								"de": "foo",
+						},
+						score: -2,
+				},
+		}
+
+		for i, c := range cases {
+				g := DiscoveryScore(c.q, c.disp, c.keys)
+				if g != c.score {
+						t.Fatalf("case %d not equal, got: %d, want: %d", i, g, c.score)
+				}
+		}
+}
+
+func TestRemoveDiacritics(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+		e     error
+	}{
+		{
+			input: "foobar",
+			want:  "foobar",
+			e:     nil,
+		},
+		{
+			input: "fòóbår",
+			want:  "foobar",
+			e:     nil,
+		},
+		{
+				input: "GÉANT",
+				want: "GEANT",
+				e: nil,
+		},
+	}
+
+	for _, c := range cases {
+		result, e := removeDiacritics(c.input)
+		if result != c.want || e != c.e {
+			t.Fatalf("Result: %s, %v Want: %s, %v", result, e, c.want, c.e)
+		}
+	}
+}

--- a/types/discovery/discovery.go
+++ b/types/discovery/discovery.go
@@ -17,6 +17,8 @@ type Organization struct {
 	DisplayName MapOrString `json:"display_name,omitempty"`
 	// OrgID is the organization ID for the server
 	OrgID string `json:"org_id"`
+	// score is the score internally used for sorting
+	Score int `json:"-"`
 }
 
 // Servers is the type that defines the upstream discovery format for the list of servers
@@ -36,6 +38,8 @@ type Server struct {
 	Type string `json:"server_type"`
 	// CountryCode is the country code of the server if Type is "secure_internet", e.g. nl
 	CountryCode string `json:"country_code"`
+	// score is the score internally used for sorting
+	Score int `json:"-"`
 }
 
 // MapOrString is a custom type as the upstream discovery format is a map or a value.

--- a/types/discovery/discovery.go
+++ b/types/discovery/discovery.go
@@ -17,9 +17,6 @@ type Organization struct {
 	DisplayName MapOrString `json:"display_name,omitempty"`
 	// OrgID is the organization ID for the server
 	OrgID string `json:"org_id"`
-	// KeywordList is the list of keywords
-	// Omitted if none is defined
-	KeywordList MapOrString `json:"keyword_list,omitempty"`
 }
 
 // Servers is the type that defines the upstream discovery format for the list of servers
@@ -35,8 +32,6 @@ type Server struct {
 	BaseURL string `json:"base_url"`
 	// DisplayName is the display name of the server, omitted if empty
 	DisplayName MapOrString `json:"display_name,omitempty"`
-	// DisplayName are the keywords of the server, omitted if empty
-	KeywordList MapOrString `json:"keyword_list,omitempty"`
 	// Type is the type of the server, "secure_internet" or "institute_access"
 	Type string `json:"server_type"`
 }

--- a/types/discovery/discovery.go
+++ b/types/discovery/discovery.go
@@ -34,6 +34,8 @@ type Server struct {
 	DisplayName MapOrString `json:"display_name,omitempty"`
 	// Type is the type of the server, "secure_internet" or "institute_access"
 	Type string `json:"server_type"`
+	// CountryCode is the country code of the server if Type is "secure_internet", e.g. nl
+	CountryCode string `json:"country_code"`
 }
 
 // MapOrString is a custom type as the upstream discovery format is a map or a value.

--- a/types/discovery/discovery.go
+++ b/types/discovery/discovery.go
@@ -1,22 +1,13 @@
 // Package discovery defines the public types that have to deal with discovery
 package discovery
 
-import (
-	"encoding/json"
-	"time"
-)
+import "encoding/json"
 
 // Organizations is the type that defines the upstream discovery format for the list of organizations
-// TODO: Discovery here is the same as the upstream discovery format, should we separate this as well?
-// Defined in URL: "https://disco.eduvpn.org/v2/organization_list.json"
+// It is a subset of the format from URL: "https://disco.eduvpn.org/v2/organization_list.json"
 type Organizations struct {
-	// Version is the version field. The Go library internally already checks for rollbacks, you can use this for logging
-	Version uint64 `json:"v"`
 	// List is the list/slice of organizations. Omitted if none are there
 	List []Organization `json:"organization_list,omitempty"`
-	// Timestamp is a timestamp that is internally used by the Go library to keep track of when the organizations was last updated
-	// You can also use this for logging
-	Timestamp time.Time `json:"go_timestamp"`
 }
 
 // Organization is the type that defines the upstream discovery format for a single organization
@@ -26,9 +17,6 @@ type Organization struct {
 	DisplayName MapOrString `json:"display_name,omitempty"`
 	// OrgID is the organization ID for the server
 	OrgID string `json:"org_id"`
-	// SecureInternetHome is the secure internet home server that belongs to this organization
-	// Omitted if none is defined
-	SecureInternetHome string `json:"secure_internet_home,omitempty"`
 	// KeywordList is the list of keywords
 	// Omitted if none is defined
 	KeywordList MapOrString `json:"keyword_list,omitempty"`
@@ -37,33 +25,20 @@ type Organization struct {
 // Servers is the type that defines the upstream discovery format for the list of servers
 // url: "https://disco.eduvpn.org/v2/server_list.json"
 type Servers struct {
-	// Version is the version field in discovery. The Go library already checks for rollbacks, use this for logging
-	Version uint64 `json:"v"`
 	// List is the actual list of servers, omitted from the JSON if empty
 	List []Server `json:"server_list,omitempty"`
-	// Timestamp is a timestamp that is internally used by the Go library to keep track of when the organizations was last updated
-	// You can also use this for logging
-	Timestamp time.Time `json:"go_timestamp"`
 }
 
 // Server is a signle discovery server
 type Server struct {
-	// AuthenticationURLTemplate is the template to be used for authentication to skip WAYF
-	AuthenticationURLTemplate string `json:"authentication_url_template,omitempty"`
 	// BaseURL is the base URL of the server which is used as an identifier for the server by the Go library
 	BaseURL string `json:"base_url"`
-	// CountryCode is the country code for the server in case of secure internet, e.g. NL
-	CountryCode string `json:"country_code,omitempty"`
 	// DisplayName is the display name of the server, omitted if empty
 	DisplayName MapOrString `json:"display_name,omitempty"`
 	// DisplayName are the keywords of the server, omitted if empty
 	KeywordList MapOrString `json:"keyword_list,omitempty"`
-	// PublicKeyList are the public keys of the server. Currently not used in this lib but returned by the upstream discovery server
-	PublicKeyList []string `json:"public_key_list,omitempty"`
 	// Type is the type of the server, "secure_internet" or "institute_access"
 	Type string `json:"server_type"`
-	// SupportContact is the list/slice of support contacts
-	SupportContact []string `json:"support_contact"`
 }
 
 // MapOrString is a custom type as the upstream discovery format is a map or a value.

--- a/wrappers/python/eduvpn_common/loader.py
+++ b/wrappers/python/eduvpn_common/loader.py
@@ -49,8 +49,8 @@ def initialize_functions(lib: CDLL) -> None:
     lib.Deregister.argtypes, lib.Deregister.restype = [], None
     lib.ExpiryTimes.argtypes, lib.ExpiryTimes.restype = [], DataError
     lib.FreeString.argtypes, lib.FreeString.restype = [c_void_p], None
-    lib.DiscoOrganizations.argtypes, lib.DiscoOrganizations.restype = [c_int], DataError
-    lib.DiscoServers.argtypes, lib.DiscoServers.restype = [c_int], DataError
+    lib.DiscoOrganizations.argtypes, lib.DiscoOrganizations.restype = [c_int, c_char_p], DataError
+    lib.DiscoServers.argtypes, lib.DiscoServers.restype = [c_int, c_char_p], DataError
     lib.GetConfig.argtypes, lib.GetConfig.restype = (
         [
             c_int,

--- a/wrappers/python/eduvpn_common/main.py
+++ b/wrappers/python/eduvpn_common/main.py
@@ -177,13 +177,13 @@ class EduVPN(object):
             forwardError(server_err)
         return server
 
-    def get_disco_organizations(self) -> str:
-        orgs, _ = self.go_cookie_function(self.lib.DiscoOrganizations)
+    def get_disco_organizations(self, search="") -> str:
+        orgs, _ = self.go_cookie_function(self.lib.DiscoOrganizations, search)
         # TODO: Log error
         return orgs
 
-    def get_disco_servers(self) -> str:
-        servers, _ = self.go_cookie_function(self.lib.DiscoServers)
+    def get_disco_servers(self, search="") -> str:
+        servers, _ = self.go_cookie_function(self.lib.DiscoServers, search)
         # TODO: Log error
         return servers
 


### PR DESCRIPTION
This patch adds a second argument to DiscoOrganizations and DiscoServers for the search query. empty string = return all, see the docs https://github.com/eduvpn/eduvpn-common/blob/discovery-search/docs/src/api/functiondocs.md#discoorganizations

Furthermore it returns a subset of the discovery to the client, this makes it trivial for us to implement discovery v3 without breaking clients as the upstream discovery format does not match the discovery format that we return to the client now. Also due to the fact that we return very few keys, there is a lot less data to convert when disco v3 is implemented.

Removed organizations keys:
- `v`: you don't need this, common uses it to check rollbacks
- `go_timestamp`: only used by go internally

Removed servers keys:
- `v`: you don't need this, common uses it to check rollbacks
- `go_timestamp`: only used by go internally

Removed server keys:
- `authentication_url_template`: only used by common to skip WAYF
- `keyword_list`: now only used by common for searching
- `public_key_list`: clients don't need this anyways, only for guest access server side
- `support_contact`: you get support contact through the common `CurrentServer` API

Removed organization keys:
- `secure_internet_home`: only common needs this
- `keyword_list`: only common needs this now for searching