### PR TITLE
Pass oauth start time in AddServer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -302,9 +302,11 @@ func (c *Client) TrySave() {
 }
 
 // AddServer adds a server with identifier and type
-func (c *Client) AddServer(ck *cookie.Cookie, identifier string, _type srvtypes.Type, ni bool) (err error) {
+func (c *Client) AddServer(ck *cookie.Cookie, identifier string, _type srvtypes.Type, ot *int64) (err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// we are non-interactive if oauth time is non-nil
+	ni := ot != nil
 	// If we have failed to add the server, we remove it again
 	// We add the server because we can then obtain it in other callback functions
 	previousState := c.FSM.Current
@@ -335,17 +337,17 @@ func (c *Client) AddServer(ck *cookie.Cookie, identifier string, _type srvtypes.
 
 	switch _type {
 	case srvtypes.TypeInstituteAccess:
-		err = c.Servers.AddInstitute(ck.Context(), c.cfg.Discovery(), identifier, ni)
+		err = c.Servers.AddInstitute(ck.Context(), c.cfg.Discovery(), identifier, ot)
 		if err != nil {
 			return i18nerr.Wrapf(err, "The institute access server with URL: '%s' could not be added", identifier)
 		}
 	case srvtypes.TypeSecureInternet:
-		err = c.Servers.AddSecure(ck.Context(), c.cfg.Discovery(), identifier, ni)
+		err = c.Servers.AddSecure(ck.Context(), c.cfg.Discovery(), identifier, ot)
 		if err != nil {
 			return i18nerr.Wrapf(err, "The secure internet server with organisation ID: '%s' could not be added", identifier)
 		}
 	case srvtypes.TypeCustom:
-		err = c.Servers.AddCustom(ck.Context(), identifier, ni)
+		err = c.Servers.AddCustom(ck.Context(), identifier, ot)
 		if err != nil {
 			return i18nerr.Wrapf(err, "The custom server with URL: '%s' could not be added", identifier)
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,7 +95,7 @@ func TestServer(t *testing.T) {
 		t.Fatalf("Registering error: %v", err)
 	}
 
-	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, false)
+	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, nil)
 	if addErr != nil {
 		t.Fatalf("Add error: %v", addErr)
 	}
@@ -143,7 +143,7 @@ func TestTokenExpired(t *testing.T) {
 		t.Fatalf("Registering error: %v", err)
 	}
 
-	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, false)
+	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, nil)
 	if addErr != nil {
 		t.Fatalf("Add error: %v", addErr)
 	}
@@ -202,7 +202,7 @@ func TestInvalidProfileCorrected(t *testing.T) {
 		t.Fatalf("Registering error: %v", err)
 	}
 
-	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, false)
+	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, nil)
 	if addErr != nil {
 		t.Fatalf("Add error: %v", addErr)
 	}
@@ -259,7 +259,8 @@ func TestConfigStartup(t *testing.T) {
 		t.Fatalf("Failed to register with error: %v", err)
 	}
 	// we set true as last argument here such that no callbacks are ran
-	err = state.AddServer(ck, serverURI, srvtypes.TypeCustom, true)
+	var ot int64 = 5
+	err = state.AddServer(ck, serverURI, srvtypes.TypeCustom, &ot)
 	if err != nil {
 		t.Fatalf("Failed to add server for trying config startup: %v", err)
 	}
@@ -319,7 +320,7 @@ func TestPreferTCP(t *testing.T) {
 		t.Fatalf("Registering error: %v", err)
 	}
 
-	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, false)
+	addErr := state.AddServer(ck, serverURI, srvtypes.TypeCustom, nil)
 	if addErr != nil {
 		t.Fatalf("Add error: %v", addErr)
 	}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -146,7 +146,7 @@ func getConfig(state *client.Client, url string, srvType srvtypes.Type) (*srvtyp
 	}
 	ck := cookie.NewWithContext(context.Background())
 	defer ck.Cancel() //nolint:errcheck
-	err := state.AddServer(ck, url, srvType, false)
+	err := state.AddServer(ck, url, srvType, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/src/api/functiondocs.md
+++ b/docs/src/api/functiondocs.md
@@ -56,7 +56,7 @@ the whole UI around it. The SetState and InState functions are useful for this
 ## AddServer
 Signature:
  ```go
-func AddServer(c C.uintptr_t, _type C.int, id *C.char, ni C.int) *C.char
+func AddServer(c C.uintptr_t, _type C.int, id *C.char, ot *C.longlong) *C.char
 ```
 AddServer adds a server to the eduvpn-common server list `c` is the cookie
 that is used for cancellation. Create a cookie first with CookieNew.
@@ -76,8 +76,11 @@ in types/server/server.go Type
 `ni` stands for non-interactive. If non-zero, any state transitions will not
 be run.
 
-This `ni` flag is useful for preprovisioned servers. For normal usage,
-you want to set this to zero (meaning: False)
+This `ot` flag is useful for preprovisioned servers; set this to non-null to
+non-interactively add a server. This flag represents the Unix time OAuth was
+last triggered, if the server needs to be added non-interactively but there
+is no token structure, set this to zero (integer) or the current Unix time.
+This value will be overwritten once OAuth is triggered.
 
 If the server cannot be added it returns the error as types/error/error.go
 Error. Note that the server is removed when an error has occured

--- a/exports/exports.go
+++ b/exports/exports.go
@@ -291,7 +291,9 @@ func Deregister() *C.char {
 //
 // `ni` stands for non-interactive. If non-zero, any state transitions will not be run.
 //
-// This `ni` flag is useful for preprovisioned servers. For normal usage, you want to set this to zero (meaning: False)
+// This `ot` flag is useful for preprovisioned servers; set this to non-null to non-interactively add a server.
+// This flag represents the Unix time OAuth was last triggered, if the server needs to be added non-interactively but there is no
+// token structure, set this to zero (integer) or the current Unix time. This value will be overwritten once OAuth is triggered.
 //
 // If the server cannot be added it returns the error as types/error/error.go Error.
 // Note that the server is removed when an error has occured
@@ -316,7 +318,7 @@ func Deregister() *C.char {
 //	}
 //
 //export AddServer
-func AddServer(c C.uintptr_t, _type C.int, id *C.char, ni C.int) *C.char {
+func AddServer(c C.uintptr_t, _type C.int, id *C.char, ot *C.longlong) *C.char {
 	state, stateErr := getVPNState()
 	if stateErr != nil {
 		return getCError(stateErr)
@@ -325,7 +327,13 @@ func AddServer(c C.uintptr_t, _type C.int, id *C.char, ni C.int) *C.char {
 	if err != nil {
 		return getCError(err)
 	}
-	err = state.AddServer(v, C.GoString(id), srvtypes.Type(_type), ni != 0)
+	// get the go oauth time
+	var auth *int64
+	if ot != nil {
+		got := int64(*ot)
+		auth = &got
+	}
+	err = state.AddServer(v, C.GoString(id), srvtypes.Type(_type), auth)
 	return getCError(err)
 }
 

--- a/internal/verify/test_data/generate_forged.py
+++ b/internal/verify/test_data/generate_forged.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import hashlib
 import base64
+import hashlib
 
 # Hash server_list.json
 

--- a/selenium_eduvpn.py
+++ b/selenium_eduvpn.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.firefox.options import Options

--- a/wrappers/python/eduvpn_common/loader.py
+++ b/wrappers/python/eduvpn_common/loader.py
@@ -1,5 +1,5 @@
 import pathlib
-from ctypes import CDLL, c_char_p, c_int, c_longlong, c_void_p, cdll, POINTER
+from ctypes import CDLL, POINTER, c_char_p, c_int, c_longlong, c_void_p, cdll
 
 from eduvpn_common import __version__
 from eduvpn_common.types import (

--- a/wrappers/python/eduvpn_common/loader.py
+++ b/wrappers/python/eduvpn_common/loader.py
@@ -1,5 +1,5 @@
 import pathlib
-from ctypes import CDLL, c_char_p, c_int, c_void_p, cdll
+from ctypes import CDLL, c_char_p, c_int, c_longlong, c_void_p, cdll, POINTER
 
 from eduvpn_common import __version__
 from eduvpn_common.types import (
@@ -66,7 +66,7 @@ def initialize_functions(lib: CDLL) -> None:
             c_int,
             c_int,
             c_char_p,
-            c_int,
+            POINTER(c_longlong),
         ],
         c_char_p,
     )

--- a/wrappers/python/eduvpn_common/main.py
+++ b/wrappers/python/eduvpn_common/main.py
@@ -1,7 +1,7 @@
 import ctypes
 import json
 from enum import IntEnum
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Optional
 
 from eduvpn_common.event import EventHandler
 from eduvpn_common.loader import initialize_functions, load_lib
@@ -151,16 +151,17 @@ class EduVPN(object):
         if register_err:
             forwardError(register_err)
 
-    def add_server(self, _type: ServerType, _id: str, ni: bool = False) -> None:
+    def add_server(self, _type: ServerType, _id: str, ot: Optional[int] = None) -> None:
         """Add a server
 
         :param _type: ServerType: The type of server e.g. SERVER.INSTITUTE_ACCESS
         :param _id: str: The identifier of the server, e.g. "https://vpn.example.com/"
-        :param ni: bool: Whether the server should be added non interactively, meaning no callbacks
+        :param ot: Optional[int]: The time when OAuth was last started.
+        if != None the server is added without any interactivity
 
         :raises WrappedError: An error by the Go library
         """
-        add_err = self.go_cookie_function(self.lib.AddServer, int(_type), _id, ni)
+        add_err = self.go_cookie_function(self.lib.AddServer, int(_type), _id, ot)
 
         if add_err:
             forwardError(add_err)

--- a/wrappers/python/eduvpn_common/types.py
+++ b/wrappers/python/eduvpn_common/types.py
@@ -1,5 +1,5 @@
-from ctypes import CDLL, CFUNCTYPE, POINTER, Structure, c_char, c_char_p, c_int, c_size_t, c_ulonglong, c_void_p, cast
-from typing import Any, Iterator, List, Tuple
+from ctypes import CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p, c_int, c_longlong, c_size_t, c_ulonglong, c_void_p, cast
+from typing import Any, Iterator, List, Optional, Tuple
 
 
 class DataError(Structure):
@@ -29,6 +29,12 @@ TokenGetter = CFUNCTYPE(c_void_p, c_char_p, c_int, POINTER(c_char), c_size_t)
 TokenSetter = CFUNCTYPE(c_void_p, c_char_p, c_int, c_char_p)
 
 
+def conv_longlongp(val: Optional[int]) -> POINTER(c_longlong):
+    if val is None:
+        return None
+    return byref(c_longlong(val))
+
+
 def encode_args(args: List[Any], types: List[Any]) -> Iterator[Any]:
     """Encode the arguments ready to be used by the Go library
 
@@ -44,6 +50,7 @@ def encode_args(args: List[Any], types: List[Any]) -> Iterator[Any]:
         # c_char_p needs the str to be encoded to bytes
         encode_map = {
             c_char_p: lambda x: x.encode("utf-8"),
+            POINTER(c_longlong): conv_longlongp,
         }
         if t in encode_map:
             arg = encode_map[t](arg)

--- a/wrappers/python/eduvpn_common/types.py
+++ b/wrappers/python/eduvpn_common/types.py
@@ -1,4 +1,18 @@
-from ctypes import CDLL, CFUNCTYPE, POINTER, Structure, byref, c_char, c_char_p, c_int, c_longlong, c_size_t, c_ulonglong, c_void_p, cast
+from ctypes import (
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+    byref,
+    c_char,
+    c_char_p,
+    c_int,
+    c_longlong,
+    c_size_t,
+    c_ulonglong,
+    c_void_p,
+    cast,
+)
 from typing import Any, Iterator, List, Optional, Tuple
 
 

--- a/wrappers/python/example/main.py
+++ b/wrappers/python/example/main.py
@@ -1,10 +1,11 @@
-from eduvpn_common import __version__ as commonver
-import eduvpn_common.main as eduvpn
-from eduvpn_common.state import State, StateType
-from eduvpn_common.server import Config, Profiles
-from typing import Optional, List, Tuple
-import webbrowser
 import sys
+import webbrowser
+from typing import List, Optional, Tuple
+
+import eduvpn_common.main as eduvpn
+from eduvpn_common import __version__ as commonver
+from eduvpn_common.server import Config, Profiles
+from eduvpn_common.state import State, StateType
 
 
 # Asks the user for a profile index

--- a/wrappers/python/tests.py
+++ b/wrappers/python/tests.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
-import unittest
-import eduvpn_common.main as eduvpn
-import eduvpn_common.event as event
-from eduvpn_common.state import State, StateType
 import os
 import sys
 import threading
+import unittest
+
+import eduvpn_common.event as event
+import eduvpn_common.main as eduvpn
+from eduvpn_common.state import State, StateType
 
 # Import project root directory where the selenium python utility is
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))


### PR DESCRIPTION
Instead of the non interactive bool, we now require OAuth start timestamp Unix *int64/*longlong. if NULL => interactive auth, else use that time for the LastAuthorizeTime, e.g. useful when migrating servers